### PR TITLE
Fix UnboundLocalError if package isn't found.

### DIFF
--- a/vayesta/__init__.py
+++ b/vayesta/__init__.py
@@ -58,9 +58,9 @@ def import_package(name, required=True):
         return package
     except ImportError:
         if required:
-            log.critical("%s not found.", package)
+            log.critical("%s not found.", name)
             raise
-        log.warning("%s not found.", package)
+        log.warning("%s not found.", name)
         return None
 
 log.debug("Required packages:")


### PR DESCRIPTION
If a package isn't present the new import_package function tries to print the package as a warning, leading to an UnboundLocalError since the package isn't present. This instead prints the name, as probably intended.