### PR TITLE
Makes Vayesta PEP8 compliant

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+
+ignore = \
+        E116, \  # Unexpected indentation (comment)
+        E126, \  # Continuation line over-indented for hanging indent
+        E221, \  # Multiple spaces before operator
+        E222, \  # Multiple spaces after operator
+        E226, \  # Missing whitespace around arithmetic operator
+        E231, \  # Missing whitespace after ",", ";" or ":"
+        E241, \  # Multiple spaces after ","
+        E265, \  # Block comment should start with "# "
+        W503, \  # Line break occurred before a binary operator
+        E721, \  # Do not compare types, use "isinstance()"
+        E731, \  # Do not assign a lambda expression, use a def instead
+        E741, \  # Do not use varialbes named "I", "O" or "l"
+        F811     # Redifinition of unused name
+
+exclude = tests, .git, .github, __pycache__, __init__.py, build, dist, *.egg
+
+max-line-length = 120

--- a/vayesta/core/ao2mo/kao2gmo.py
+++ b/vayesta/core/ao2mo/kao2gmo.py
@@ -14,12 +14,12 @@ import pyscf
 import pyscf.pbc
 import pyscf.pbc.tools
 # Package
-from vayesta.core.util import *
+from vayesta.core.util import einsum, timer
 import vayesta.libs
 from vayesta.core.ao2mo import helper
 
-
 log = logging.getLogger(__name__)
+
 
 def kao2gmo_cderi(gdf, mo_coeffs, make_real=True, blksize=None, tril_kij=True, driver='c'):
     """Transform density-fitted ERIs from primtive cell k-AO, to Gamma-point MOs.
@@ -69,13 +69,13 @@ def kao2gmo_cderi(gdf, mo_coeffs, make_real=True, blksize=None, tril_kij=True, d
 
     if blksize is None:
         max_memory = int(1e9)   # 1 GB
-        max_size = int(max_memory / (nao**2 * 16)) # how many naux fit in max_memory
+        max_size = int(max_memory / (nao**2 * 16))  # how many naux fit in max_memory
         blksize = np.clip(max_size, 1, int(1e9))
         log.debugv("max_memory= %.3f MB  max_size= %d  blksize= %d", max_memory/1e6, max_size, blksize)
 
     log.debugv("driver= %s", driver)
     if driver == 'python':
-        transform = lambda cderi_kij, mo1_ki, mo2_kj : einsum('Lab,ai,bj->Lij', cderi_kij, mo1_ki.conj(), mo2_kj)
+        transform = lambda cderi_kij, mo1_ki, mo2_kj: einsum('Lab,ai,bj->Lij', cderi_kij, mo1_ki.conj(), mo2_kj)
     elif driver == 'c':
         libcore = vayesta.libs.libcore
 
@@ -181,7 +181,7 @@ if __name__ == '__main__':
 
     import vayesta.core.ao2mo
 
-    import kao2gmo #import gdf_to_eris
+    import kao2gmo  # import gdf_to_eris
 
     card = 'D'
 
@@ -252,7 +252,7 @@ if __name__ == '__main__':
     t0 = timer()
     cderi, cderi_neg = kao2gmo_cderi(gdf, (mo_coeff, mo_coeff), driver='c')
     print("Time k(C)= %.4f" % (timer()-t0))
-    eri2 = einsum('Lij,Lkl->ijkl', cderi ,cderi)
+    eri2 = einsum('Lij,Lkl->ijkl', cderi, cderi)
     if cderi_neg is not None:
         eri2 -= einsum('Lij,Lkl->ijkl', cderi_neg, cderi_neg)
 

--- a/vayesta/core/ao2mo/postscf_ao2mo.py
+++ b/vayesta/core/ao2mo/postscf_ao2mo.py
@@ -13,7 +13,7 @@ from pyscf.cc.uccsd import _ChemistsERIs as UCCSD_ChemistsERIs
 from pyscf.cc.dfccsd import _ChemistsERIs as DFCCSD_ChemistsERIs
 from pyscf.cc.ccsd import _ChemistsERIs as CCSD_ChemistsERIs
 
-from vayesta.core.util import *
+from vayesta.core.util import dot, replace_attr, brange
 from .kao2gmo import kao2gmo_cderi
 
 
@@ -67,6 +67,7 @@ def postscf_ao2mo(postscf, mo_coeff=None, fock=None, mo_energy=None, e_hf=None):
         eris.mo_energy = mo_energy
 
     return eris
+
 
 def postscf_kao2gmo(postscf, gdf, fock, mo_energy, e_hf, mo_coeff=None):
     """k-AO to Gamma-MO transformation of ERIs for post-SCF calculations of supercells.
@@ -151,6 +152,7 @@ def postscf_kao2gmo(postscf, gdf, fock, mo_energy, e_hf, mo_coeff=None):
             eris.vvvv = _contract_cderi(cderi, cderi_neg, block='vvvv', nocc=nocc, pack_left=pack, pack_right=pack)
 
     return eris
+
 
 def postscf_kao2gmo_uhf(postscf, gdf, fock, mo_energy, e_hf, mo_coeff=None):
     """k-AO to Gamma-MO transformation of ERIs for unrestricted post-SCF calculations of supercells.
@@ -253,10 +255,11 @@ def postscf_kao2gmo_uhf(postscf, gdf, fock, mo_energy, e_hf, mo_coeff=None):
 
     return eris
 
+
 def _contract_cderi(cderi, cderi_neg, block=None, nocc=None, pack_left=False, pack_right=False, imag_tol=1e-8):
     if block is not None:
         slices = {'o': np.s_[:nocc], 'v': np.s_[nocc:]}
-        get_slices = (lambda block : (slices[block[0]], slices[block[1]]))
+        get_slices = (lambda block: (slices[block[0]], slices[block[1]]))
         si, sj = get_slices(block[:2])
         sk, sl = get_slices(block[2:])
     else:
@@ -282,7 +285,7 @@ def _contract_cderi(cderi, cderi_neg, block=None, nocc=None, pack_left=False, pa
     if pack_right:
         cderi_right = pyscf.lib.pack_tril(cderi_right)
     # Avoid allocating another N^4 object:
-    max_memory = int(3e8) # 300 MB
+    max_memory = int(3e8)  # 300 MB
     nblks = int((eri.size * 8 * (1+np.iscomplexobj(eri)))/max_memory)
     size = cderi_left.shape[1]
     blksize = int(size/max(nblks, 1))
@@ -293,11 +296,12 @@ def _contract_cderi(cderi, cderi_neg, block=None, nocc=None, pack_left=False, pa
     assert (eri.size == 0) or (abs(eri.imag).max() < imag_tol)
     return eri
 
+
 def _contract_cderi_mixed(cderi, cderi_neg, block=None, nocc=None, pack_left=False, pack_right=False, imag_tol=1e-8):
     if block is not None:
         noccl, noccr = nocc
         slices = {'o': np.s_[:noccl], 'v': np.s_[noccl:], 'O': np.s_[:noccr], 'V': np.s_[noccr:]}
-        get_slices = (lambda block : (slices[block[0]], slices[block[1]]))
+        get_slices = (lambda block: (slices[block[0]], slices[block[1]]))
         si, sj = get_slices(block[:2])
         sk, sl = get_slices(block[2:])
     else:
@@ -323,7 +327,7 @@ def _contract_cderi_mixed(cderi, cderi_neg, block=None, nocc=None, pack_left=Fal
     if pack_right:
         cderi_right = pyscf.lib.pack_tril(cderi_right)
     # Avoid allocating another N^4 object:
-    max_memory = int(3e8) # 300 MB
+    max_memory = int(3e8)  # 300 MB
     nblks = int((eri.size * 8 * (1+np.iscomplexobj(eri)))/max_memory)
     size = cderi_left.shape[1]
     blksize = int(size/max(nblks, 1))

--- a/vayesta/core/bath/ewdmet.py
+++ b/vayesta/core/bath/ewdmet.py
@@ -1,10 +1,11 @@
 import numpy as np
 
 from vayesta.core.linalg import recursive_block_svd
-from vayesta.core.util import *
+from vayesta.core.util import dot
 from vayesta.core import spinalg
 
 from .bath import Bath
+
 
 class EwDMET_Bath(Bath):
 

--- a/vayesta/core/bath/helper.py
+++ b/vayesta/core/bath/helper.py
@@ -1,9 +1,19 @@
 import numpy as np
 
-from vayesta.core.util import *
+from vayesta.core.util import einsum
 
-def make_histogram(values, bins, labels=None, binwidth=5, height=6, fill=':', show_number=False, invertx=True,
-        rstrip=True):
+
+def make_histogram(
+        values,
+        bins,
+        labels=None,
+        binwidth=5,
+        height=6,
+        fill=':',
+        show_number=False,
+        invertx=True,
+        rstrip=True,
+):
     hist = np.histogram(values, bins)[0]
     if invertx:
         bins, hist = bins[::-1], hist[::-1]
@@ -50,6 +60,7 @@ def make_histogram(values, bins, labels=None, binwidth=5, height=6, fill=':', sh
     txt = '\n'.join(lines)
     return txt
 
+
 def make_horizontal_histogram(values, bins=None, maxbarlength=50, invertx=True):
     if bins is None:
         bins = np.hstack([-np.inf, np.logspace(-3, -12, 10)[::-1], np.inf])
@@ -70,6 +81,7 @@ def make_horizontal_histogram(values, bins=None, maxbarlength=50, invertx=True):
         lines.append("  %5.0e - %5.0e  %4d   |%s" % (bins[i+1], bins[i], cumsum, bar))
     txt = '\n'.join(lines)
     return txt
+
 
 def transform_mp2_eris(eris, c_occ, c_vir, ovlp):  # pragma: no cover
     """Transform eris of kind (ov|ov) (occupied-virtual-occupied-virtual)
@@ -111,9 +123,10 @@ def transform_mp2_eris(eris, c_occ, c_vir, ovlp):  # pragma: no cover
     eris.mo_energy = np.diag(eris.fock)
     return eris
 
+
 if __name__ == '__main__':
     vals = sorted(np.random.rand(30))
-    print(make_vertical_histogram(vals))
+    print(make_histogram(vals))
     print('')
     bins = np.linspace(0, 1, 12)
     #for line in horizontal_histogram(vals, bins):

--- a/vayesta/core/cmdargs.py
+++ b/vayesta/core/cmdargs.py
@@ -5,17 +5,31 @@ DEFAULT_LOGLVL = 10
 # In future, INFO level will be default:
 #DEFAULT_LOGLVL = 20
 
+
 def parse_cmd_args():
     parser = argparse.ArgumentParser(allow_abbrev=False)
     #parser.add_argument('-o', '--output', help="If set, redirect all logging to this file.")
-    parser.add_argument('-o', '--output-dir', default='vayesta_output', help="Directory for Vayesta output files.")
+    parser.add_argument(
+            '-o',
+            '--output-dir',
+            default='vayesta_output',
+            help="Directory for Vayesta output files.",
+    )
     parser.add_argument('--log', default='log.txt', help="Log to this file in addition to stdout and stderr.")
     parser.add_argument('--errlog', default='errors.txt', help="Warnings and errors will be written to this file.")
-    parser.add_argument('--errlog-level', type=int, default=30, help="Determines the default logging level for the error log.")
+    parser.add_argument(
+            '--errlog-level',
+            type=int,
+            default=30,
+            help="Determines the default logging level for the error log.",
+    )
     parser.add_argument('-q', '--quiet', action='store_true', help='Do not print to terminal')
-    parser.add_argument('-v',   action='store_const', dest='loglevel', const=15, default=DEFAULT_LOGLVL)    # Enables infov
-    parser.add_argument('-vv',  action='store_const', dest='loglevel', const=10)                            # Enables timing
-    parser.add_argument('-vvv', action='store_const', dest='loglevel', const=1)                             # Enables debugv, timingv, trace
+    # Enables infov:
+    parser.add_argument('-v',   action='store_const', dest='loglevel', const=15, default=DEFAULT_LOGLVL)
+    # Enables timing:
+    parser.add_argument('-vv',  action='store_const', dest='loglevel', const=10)
+    # Enables debugv, timingv, trace:
+    parser.add_argument('-vvv', action='store_const', dest='loglevel', const=1)
     parser.add_argument('--mpi', action='store_true', dest='mpi', default='auto')
     parser.add_argument('--no-mpi', action='store_false', dest='mpi', default='auto')
     args, unknown_args = parser.parse_known_args()

--- a/vayesta/core/fragmentation/fragmentation.py
+++ b/vayesta/core/fragmentation/fragmentation.py
@@ -2,8 +2,9 @@ import numpy as np
 import scipy
 import scipy.linalg
 
-from vayesta.core.util import *
+from vayesta.core.util import dot, timer, time_string, fix_orbital_sign
 from . import helper
+
 
 def check_orthonormal(log, mo_coeff, ovlp, mo_name="orbital", tol=1e-7):
     """Check orthonormality of mo_coeff.
@@ -200,7 +201,8 @@ class Fragmentation:
 
     def symmetric_orth(self, mo_coeff, ovlp=None, tol=1e-15):
         """Use as mo_coeff = np.dot(mo_coeff, x) to get orthonormal orbitals."""
-        if ovlp is None: ovlp = self.get_ovlp()
+        if ovlp is None:
+            ovlp = self.get_ovlp()
         m = dot(mo_coeff.T, ovlp, mo_coeff)
         e, v = scipy.linalg.eigh(m)
         e_min = e.min()
@@ -223,12 +225,14 @@ class Fragmentation:
     #    return l2, linf
 
     def check_orthonormal(self, mo_coeff, mo_name=None, tol=1e-7):
-        if mo_name is None: mo_name = self.name
+        if mo_name is None:
+            mo_name = self.name
         return check_orthonormal(self.log, mo_coeff, self.get_ovlp(), mo_name=mo_name, tol=tol)
 
     def get_atom_indices_symbols(self, atoms):
         """Convert a list of integer or strings to atom indices and symbols."""
-        if np.ndim(atoms) == 0: atoms = [atoms]
+        if np.ndim(atoms) == 0:
+            atoms = [atoms]
 
         if isinstance(atoms[0], (int, np.integer)):
             atom_indices = atoms
@@ -264,7 +268,8 @@ class Fragmentation:
             List of fragment orbitals indices, with coefficients corresponding to `self.coeff[:,indices]`.
         """
         atom_indices, atom_symbols = self.get_atom_indices_symbols(atoms)
-        if name is None: name = '/'.join(atom_symbols)
+        if name is None:
+            name = '/'.join(atom_symbols)
         self.log.debugv("Atom indices of fragment %s: %r", name, atom_indices)
         self.log.debugv("Atom symbols of fragment %s: %r", name, atom_symbols)
         # Indices of IAOs based at atoms
@@ -277,7 +282,8 @@ class Fragmentation:
 
     def get_orbital_indices_labels(self, orbitals):
         """Convert a list of integer or strings to orbital indices and labels."""
-        if np.ndim(orbitals) == 0: orbitals = [orbitals]
+        if np.ndim(orbitals) == 0:
+            orbitals = [orbitals]
 
         if isinstance(orbitals[0], (int, np.integer)):
             orbital_indices = orbitals
@@ -298,7 +304,8 @@ class Fragmentation:
         if atom_filter is not None:
             raise NotImplementedError()
         indices, orbital_labels = self.get_orbital_indices_labels(orbitals)
-        if name is None: name = '/'.join(orbital_labels)
+        if name is None:
+            name = '/'.join(orbital_labels)
         self.log.debugv("Orbital indices of fragment %s: %r", name, indices)
         self.log.debugv("Orbital labels of fragment %s: %r", name, orbital_labels)
         return name, indices

--- a/vayesta/core/fragmentation/iaopao.py
+++ b/vayesta/core/fragmentation/iaopao.py
@@ -3,7 +3,7 @@ import numpy as np
 import pyscf
 import pyscf.lo
 
-from vayesta.core.util import *
+from vayesta.core.util import dot
 from vayesta.core import spinalg
 from vayesta.core.fragmentation.iao import IAO_Fragmentation
 from vayesta.core.fragmentation.iao import IAO_Fragmentation_UHF
@@ -52,8 +52,10 @@ class IAOPAO_Fragmentation(IAO_Fragmentation):
 
         # Orthogonalize PAOs:
         x, e_min = self.symmetric_orth(pao_coeff, ovlp)
-        self.log.debugv("Lowdin orthogonalization of PAOs: n(in)= %3d -> n(out)= %3d , e(min)= %.3e",
-                x.shape[0], x.shape[1], e_min)
+        self.log.debugv(
+                "Lowdin orthogonalization of PAOs: n(in)= %3d -> n(out)= %3d , e(min)= %.3e",
+                x.shape[0], x.shape[1], e_min,
+        )
         if e_min < 1e-10:
             self.log.warning("Small eigenvalue in Lowdin orthogonalization: %.3e !", e_min)
         pao_coeff = np.dot(pao_coeff, x)
@@ -61,7 +63,8 @@ class IAOPAO_Fragmentation(IAO_Fragmentation):
 
     def get_coeff(self, order=None):
         """Make projected atomic orbitals (PAOs)."""
-        if order is None: order = self.order
+        if order is None:
+            order = self.order
         iao_coeff = IAO_Fragmentation.get_coeff(self, add_virtuals=False)
         pao_coeff = self.get_pao_coeff(iao_coeff)
         coeff = spinalg.hstack_matrices(iao_coeff, pao_coeff)
@@ -73,7 +76,8 @@ class IAOPAO_Fragmentation(IAO_Fragmentation):
         return coeff
 
     def get_labels(self, order=None):
-        if order is None: order = self.order
+        if order is None:
+            order = self.order
         iao_labels = super().get_labels()
         core, valence, rydberg = pyscf.lo.nao._core_val_ryd_list(self.mol)
         pao_labels = [tuple(x) for x in np.asarray(self.mol.ao_labels(None), dtype=tuple)[rydberg]]
@@ -85,11 +89,13 @@ class IAOPAO_Fragmentation(IAO_Fragmentation):
     def search_labels(self, labels):
         return self.mol.search_ao_label(labels)
 
+
 class IAOPAO_Fragmentation_UHF(IAOPAO_Fragmentation, IAO_Fragmentation_UHF):
 
     def get_coeff(self, order=None):
         """Make projected atomic orbitals (PAOs)."""
-        if order is None: order = self.order
+        if order is None:
+            order = self.order
         iao_coeff = IAO_Fragmentation_UHF.get_coeff(self, add_virtuals=False)
 
         pao_coeff_a = IAOPAO_Fragmentation.get_pao_coeff(self, iao_coeff[0])
@@ -105,6 +111,7 @@ class IAOPAO_Fragmentation_UHF(IAOPAO_Fragmentation, IAO_Fragmentation_UHF):
         if order is not None:
             return (coeff[0][:,order], coeff[1][:,order])
         return coeff
+
 
 if __name__ == '__main__':
 

--- a/vayesta/core/fragmentation/sao.py
+++ b/vayesta/core/fragmentation/sao.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from vayesta.core.util import *
 from .fragmentation import Fragmentation
 from .ufragmentation import Fragmentation_UHF
+
 
 class SAO_Fragmentation(Fragmentation):
 
@@ -14,8 +14,10 @@ class SAO_Fragmentation(Fragmentation):
         if np.allclose(ovlp, idt):
             return idt
         x, e_min = self.symmetric_orth(idt, ovlp)
-        self.log.debugv("Lowdin orthogonalization of AOs: n(in)= %3d -> n(out)= %3d , e(min)= %.3e",
-                x.shape[0], x.shape[1], e_min)
+        self.log.debugv(
+                "Lowdin orthogonalization of AOs: n(in)= %3d -> n(out)= %3d , e(min)= %.3e",
+                x.shape[0], x.shape[1], e_min,
+        )
         if e_min < 1e-10:
             self.log.warning("Small eigenvalue in Lowdin orthogonalization: %.3e !", e_min)
         self.check_orthonormal(x)
@@ -26,6 +28,7 @@ class SAO_Fragmentation(Fragmentation):
 
     def search_labels(self, labels):
         return self.mol.search_ao_label(labels)
+
 
 class SAO_Fragmentation_UHF(Fragmentation_UHF, SAO_Fragmentation):
 

--- a/vayesta/core/fragmentation/site.py
+++ b/vayesta/core/fragmentation/site.py
@@ -1,9 +1,11 @@
 from .sao import SAO_Fragmentation
 from .sao import SAO_Fragmentation_UHF
 
+
 class Site_Fragmentation(SAO_Fragmentation):
 
     name = "Site"
+
 
 class Site_Fragmentation_UHF(SAO_Fragmentation_UHF):
 

--- a/vayesta/core/fragmentation/ufragmentation.py
+++ b/vayesta/core/fragmentation/ufragmentation.py
@@ -4,6 +4,7 @@ from .fragmentation import Fragmentation
 
 # TODO: Allow different indices for alpha and beta
 
+
 class Fragmentation_UHF(Fragmentation):
     """Fragmentation for unrestricted HF."""
 

--- a/vayesta/core/helper.py
+++ b/vayesta/core/helper.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def orbital_sign_convention(mo_coeff, inplace=True):
     if not inplace:
         mo_coeff = mo_coeff.copy()
@@ -11,6 +12,7 @@ def orbital_sign_convention(mo_coeff, inplace=True):
     signs[swap] = -1
     return mo_coeff, signs
 
+
 # --- Packing/unpacking arrays
 
 def get_dtype_int(obj):
@@ -19,12 +21,14 @@ def get_dtype_int(obj):
     dtint = np.asarray(obj.dtype.char, dtype='a8').view(int)[()]
     return dtint
 
+
 def get_dtype(dtint):
     if dtint == 0:
         return None
     val = np.asarray(dtint).view('a8')[()]
     dtype = np.dtype(val)
     return dtype
+
 
 def pack_metadata(array, maxdim=8):
     if np.ndim(array) > maxdim:
@@ -39,11 +43,13 @@ def pack_metadata(array, maxdim=8):
     metadata = [dtint, ndim] + shape
     return np.asarray(metadata, dtype=int)
 
+
 def unpack_metadata(array, maxdim=8):
     metadata = array[:maxdim+2].view(int)
     dtype = get_dtype(metadata[0])
     ndim, shape = metadata[1], metadata[2:]
     return dtype, ndim, shape
+
 
 def pack_arrays(*arrays, dtype=float, maxdim=8):
     """Pack multiple arrays into a single array of data type `dtype`.
@@ -61,6 +67,7 @@ def pack_arrays(*arrays, dtype=float, maxdim=8):
     for array in arrays:
         packed.append(pack(array))
     return np.hstack(packed)
+
 
 def unpack_arrays(packed, dtype=float, maxdim=8):
     """Unpack a single array of data type `dtype` into multiple arrays.
@@ -92,7 +99,7 @@ if __name__ == '__main__':
         np.random.rand(70),
         #np.random.rand(70)*1j,
         #np.asarray([True, False, False])
-        ]
+    ]
     pack = pack_arrays(*arrays_in)
 
     print(np.sum([sys.getsizeof(x) for x in arrays_in]))

--- a/vayesta/core/linalg.py
+++ b/vayesta/core/linalg.py
@@ -1,8 +1,8 @@
 import logging
 import numpy as np
 
-
 log = logging.getLogger(__name__)
+
 
 def recursive_block_svd(a, n, tol=1e-10, maxblock=100):
     """Perform SVD of rectangular, offdiagonal blocks of a matrix recursively.
@@ -39,14 +39,15 @@ def recursive_block_svd(a, n, tol=1e-10, maxblock=100):
 
     for order in range(1, maxblock+1):
         blk = np.linalg.multi_dot((coeff.T, a, coeff))[low,env]
-        nmax = blk.shape[-1]
         assert blk.ndim == 2
         assert np.all(np.asarray(blk.shape) > 0)
 
         u, s, vh = np.linalg.svd(blk)
         rot = vh.T.conj()
         ncpl = np.count_nonzero(s >= tol)
-        log.debugv("Order= %3d - found %3d bath orbitals in %3d with tol= %8.2e: SV= %r" % (order, ncpl, blk.shape[1], tol, s[:ncpl].tolist()))
+        log.debugv("Order= %3d - found %3d bath orbitals in %3d with tol= %8.2e: SV= %r" % (
+            order, ncpl, blk.shape[1], tol, s[:ncpl].tolist(),
+        ))
         if ncpl == 0:
             log.debugv("Remaining environment orbitals are decoupled; exiting.")
             break

--- a/vayesta/core/spinalg.py
+++ b/vayesta/core/spinalg.py
@@ -2,6 +2,7 @@
 same functions"""
 
 import numpy as np
+import scipy.linalg
 from vayesta.core import util
 
 __all__ = ['add_numbers', 'hstack_matrices']
@@ -17,6 +18,7 @@ def add_numbers(*args):
                 sum([arg[1] for arg in args]))
     raise ValueError
 
+
 def hstack_matrices(*args, ignore_none=True):
     if ignore_none:
         args = [x for x in args if x is not None]
@@ -28,6 +30,7 @@ def hstack_matrices(*args, ignore_none=True):
         return (util.hstack(*[arg[0] for arg in args]),
                 util.hstack(*[arg[1] for arg in args]))
     raise ValueError
+
 
 def dot(*args, out=None):
     """Generalizes dot with or without spin channel: ij,jk->ik or Sij,Sjk->Sik
@@ -46,6 +49,7 @@ def dot(*args, out=None):
     args_a = [(x if np.ndim(x[0]) < 2 else x[0]) for x in args]
     args_b = [(x if np.ndim(x[1]) < 2 else x[1]) for x in args]
     return (util.dot(*args_a, out=out[0]), util.dot(*args_b, out=out[1]))
+
 
 def eigh(a, b=None, *args, **kwargs):
     ndim = np.ndim(a[0]) + 1

--- a/vayesta/core/symmetry/operation.py
+++ b/vayesta/core/symmetry/operation.py
@@ -8,14 +8,12 @@ import scipy.spatial
 import pyscf
 import pyscf.symm
 
-import vayesta
-import vayesta.core
-from vayesta.core.util import *
-
+from vayesta.core.util import einsum, AbstractMethodError
 
 log = logging.getLogger(__name__)
 
 BOHR = 0.529177210903
+
 
 class SymmetryOperation:
 
@@ -41,10 +39,12 @@ class SymmetryOperation:
     def __call__(self):
         raise AbstractMethodError()
 
+
 class SymmetryIdentity(SymmetryOperation):
 
     def __call__(self, a, **kwargs):
         return a
+
 
 class SymmetryRotation(SymmetryOperation):
 
@@ -204,7 +204,6 @@ class SymmetryTranslation(SymmetryOperation):
     @property
     def vector_xyz(self):
         """Translation vector in real-space coordinates (unit = Bohr)."""
-        latvecs = self.lattice_vectors
         vector_xyz = np.dot(self.lattice_vectors, self.vector)
         return vector_xyz
 
@@ -231,10 +230,12 @@ class SymmetryTranslation(SymmetryOperation):
         def get_atom_at(pos):
             """pos in internal coordinates."""
             for dx, dy, dz in itertools.product([0,-1,1], repeat=3):
-                if self.group.dimension in (1, 2) and (dz != 0): continue
-                if self.group.dimension == 1 and (dy != 0): continue
+                if self.group.dimension in (1, 2) and (dz != 0):
+                    continue
+                if self.group.dimension == 1 and (dy != 0):
+                    continue
                 dr = np.asarray([dx, dy, dz])
-                phase = np.product(self.boundary_phases[dr!=0])
+                phase = np.product(self.boundary_phases[dr != 0])
                 dists = np.linalg.norm(atom_coords_abc + dr - pos, axis=1)
                 idx = np.argmin(dists)
                 if (dists[idx] < self.xtol):
@@ -288,6 +289,8 @@ class SymmetryTranslation(SymmetryOperation):
         assert np.all(np.arange(self.nao)[reorder][inverse] == np.arange(self.nao))
         return reorder, inverse, phases
 
+
+# flake8: noqa
 if __name__ == '__main__':
 
     def test_translation():

--- a/vayesta/core/symmetry/symmetry.py
+++ b/vayesta/core/symmetry/symmetry.py
@@ -11,6 +11,7 @@ def unit_vector(vector):
     """Returns the unit vector of the vector."""
     return vector / np.linalg.norm(vector)
 
+
 def angle_between(v1, v2):
     """Returns the angle in radians between vectors 'v1' and 'v2'::
 
@@ -24,6 +25,7 @@ def angle_between(v1, v2):
     u1 = unit_vector(v1)
     u2 = unit_vector(v2)
     return np.arccos(np.clip(np.dot(u1, u2), -1.0, 1.0))
+
 
 class Symmetry:
 
@@ -58,7 +60,7 @@ class Symmetry:
         mf = getattr(self.mf, 'kmf', self.mf)
         return mf.mol.natm
 
-    def get_unique_atoms(self): #, r_tol=1e-5):
+    def get_unique_atoms(self):  # , r_tol=1e-5):
         return list(range(self.natom_unique))
 
         #if self.nsubcells is None:
@@ -116,7 +118,6 @@ class Symmetry:
             return False
         return True
 
-
     def find_subcells(self, respect_basis=True, respect_labels=False, respect_dm1=None, r_tol=1e-5, dm1_tol=1e-6):
         """Find subcells within cell, with unit cell vectors parallel to the supercell.
 
@@ -125,7 +126,8 @@ class Symmetry:
         respect_basis: bool, optional
             If True, the basis functions are considered when determining the symmetry. Default: True.
         respect_labels: bool, optional
-            If True, the labels of atoms (such as "H1" or "C*") are considered when determining the symmetry. Default: False.
+            If True, the labels of atoms (such as "H1" or "C*") are considered when determining the symmetry.
+            Default: False.
         respect_dm1: array or None, optional
             If a (tuple of) density-matrix is passed, it is considered when determining the symmetry. Default: None.
         r_tol: float, optional
@@ -222,7 +224,6 @@ class Symmetry:
         nsubcells = np.rint(nsubcells).astype(int)
         return nsubcells
 
-
     #def find_primitive_cells_old(self, tol=1e-5):
     #    if self.pbcndims == 0:
     #        raise ValueError()
@@ -235,7 +236,6 @@ class Symmetry:
 
     #    #print(coords[3] - coords[1])
     #    #print(aavecs[3,1])
-
 
     #    tvecs = aavecs.reshape(self.natom*self.natom, 3)
     #    #tvecs = np.unique(tvecs, axis=0)
@@ -274,7 +274,7 @@ class Symmetry:
     #    print(tvecs_dim[1])
     #    print(tvecs_dim[2])
 
-    #    # Find most 
+    #    # Find most
     #    for d in range(3):
     #        pass
 
@@ -298,7 +298,6 @@ if __name__ == '__main__':
     cell.basis = 'def2-svp'
     cell.build()
     #cell.dimension = 2
-
 
     sc = [1, 2, 3]
     cell = pyscf.pbc.tools.super_cell(cell, sc)

--- a/vayesta/core/symmetry/tsymmetry.py
+++ b/vayesta/core/symmetry/tsymmetry.py
@@ -9,12 +9,14 @@ from pyscf.lib.parameters import BOHR
 
 log = logging.getLogger(__name__)
 
+
 def to_bohr(a, unit):
     if unit[0].upper() == 'A':
-        return  a/BOHR
+        return a/BOHR
     if unit[0].upper() == 'B':
         return a
     raise ValueError("Unknown unit: %s" % unit)
+
 
 def get_mesh_tvecs(cell, tvecs, unit='Ang'):
     rvecs = cell.lattice_vectors()
@@ -36,6 +38,7 @@ def get_mesh_tvecs(cell, tvecs, unit='Ang'):
         raise ValueError("Unknown set of T-vectors: %r" % tvecs)
     return mesh, tvecs
 
+
 def loop_tvecs(cell, tvecs, unit='Ang', include_origin=False):
     mesh, tvecs = get_mesh_tvecs(cell, tvecs, unit)
     log.debugv("nx= %d ny= %d nz= %d", *mesh)
@@ -45,6 +48,7 @@ def loop_tvecs(cell, tvecs, unit='Ang', include_origin=False):
             continue
         t = dx*tvecs[0] + dy*tvecs[1] + dz*tvecs[2]
         yield (dx, dy, dz), t
+
 
 def tsymmetric_atoms(cell, rvecs, xtol=1e-8, unit='Ang', check_element=True, check_basis=True):
     """Get indices of translationally symmetric atoms.
@@ -103,6 +107,7 @@ def tsymmetric_atoms(cell, rvecs, xtol=1e-8, unit='Ang', check_element=True, che
 
     return indices
 
+
 def compare_atoms(cell, atm1, atm2, check_basis=True):
     type1 = cell.atom_pure_symbol(atm1)
     type2 = cell.atom_pure_symbol(atm2)
@@ -115,6 +120,7 @@ def compare_atoms(cell, atm1, atm2, check_basis=True):
     if bas1 != bas2:
         return False
     return True
+
 
 def reorder_atoms(cell, tvec, boundary=None, unit='Ang', check_basis=True):
     """Reordering of atoms for a given translation.
@@ -162,10 +168,12 @@ def reorder_atoms(cell, tvec, boundary=None, unit='Ang', check_basis=True):
 
     def get_atom_at(pos, xtol=1e-8):
         for dx, dy, dz in itertools.product([0,-1,1], repeat=3):
-            if cell.dimension in (1, 2) and (dz != 0): continue
-            if cell.dimension == 1 and (dy != 0): continue
+            if cell.dimension in (1, 2) and (dz != 0):
+                continue
+            if cell.dimension == 1 and (dy != 0):
+                continue
             dr = np.asarray([dx, dy, dz])
-            phase = np.product(boundary[dr!=0])
+            phase = np.product(boundary[dr != 0])
             #log.debugv("dx= %d dy= %d dz= %d phase= %d", dx, dy, dz, phase)
             #print(atom_coords.shape, dr.shape, pos.shape)
             dists = np.linalg.norm(atom_coords + dr - pos, axis=1)
@@ -195,6 +203,7 @@ def reorder_atoms(cell, tvec, boundary=None, unit='Ang', check_basis=True):
     assert np.all(np.arange(cell.natm)[reorder][inverse] == np.arange(cell.natm))
 
     return reorder, inverse, phases
+
 
 def reorder_atoms2aos(cell, atom_reorder, atom_phases):
     if atom_reorder is None:
@@ -245,6 +254,7 @@ def reorder_aos(cell, tvec, unit='Ang'):
 
     #return reorder, inverse, phases
 
+
 def _make_reorder_op(reorder, phases):
     def reorder_op(a, axis=0):
         if isinstance(a, (tuple, list)):
@@ -253,6 +263,7 @@ def _make_reorder_op(reorder, phases):
         return np.take(a, reorder, axis=axis) * phases[bc]
     return reorder_op
 
+
 def get_tsymmetry_op(cell, tvec, unit='Ang'):
     reorder, inverse, phases = reorder_aos(cell, tvec, unit=unit)
     if reorder is None:
@@ -260,6 +271,7 @@ def get_tsymmetry_op(cell, tvec, unit='Ang'):
         return None
     tsym_op = _make_reorder_op(reorder, phases)
     return tsym_op
+
 
 if __name__ == '__main__':
     import vayesta
@@ -270,8 +282,8 @@ if __name__ == '__main__':
     import pyscf.pbc.tools
 
     cell = pyscf.pbc.gto.Cell()
-    cell.atom='H 0 0 0, H 0 1 2'
-    cell.basis='sto-3g'
+    cell.atom = 'H 0 0 0, H 0 1 2'
+    cell.basis = 'sto-3g'
     cell.a = np.eye(3)
     cell.dimension = 1
     cell.build()

--- a/vayesta/core/types/cluster.py
+++ b/vayesta/core/types/cluster.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .orbitals import Orbitals
-from vayesta.core.spinalg import *
+from vayesta.core.spinalg import hstack_matrices, add_numbers
 
 __all__ = ['Cluster', 'ClusterRHF', 'ClusterUHF']
 
@@ -124,16 +124,18 @@ class Cluster:
         cp.frozen_orbitals.basis_transform(trafo, inplace=True)
         return cp
 
+
 class ClusterRHF(Cluster):
 
     def __repr__(self):
-        return '%s(norb_active= %d, norb_frozen= %d)' % (self.__class__.__name__,
-                self.norb_active, self.norb_frozen)
+        return '%s(norb_active= %d, norb_frozen= %d)' % (
+                self.__class__.__name__, self.norb_active, self.norb_frozen,
+        )
 
     # Indices and slices
 
     def get_active_slice(self):
-        return np.s_[self.nocc_frozen : self.nocc_frozen+self.norb_active]
+        return np.s_[self.nocc_frozen: self.nocc_frozen+self.norb_active]
 
     def get_active_indices(self):
         return list(range(self.nocc_frozen, self.nocc_frozen+self.norb_active))
@@ -147,7 +149,7 @@ class ClusterRHF(Cluster):
         lines += [fmt % ("Active", "Frozen", "Total")]
         lines += [fmt % (15*'-', 15*'-', 5*'-')]
         fmt = '  %-8s' + 2*'   %5d (%6.1f%%)' + '   %5d'
-        get_values = lambda a, f, n : (a, 100*a/n, f, 100*f/n, n)
+        get_values = lambda a, f, n: (a, 100*a/n, f, 100*f/n, n)
         lines += [fmt % ("Occupied", *get_values(self.nocc_active, self.nocc_frozen, self.nocc_total))]
         lines += [fmt % ("Virtual",  *get_values(self.nvir_active, self.nvir_frozen, self.nvir_total))]
         lines += [fmt % ("Total",    *get_values(self.norb_active, self.norb_frozen, self.norb_total))]
@@ -157,8 +159,9 @@ class ClusterRHF(Cluster):
 class ClusterUHF(Cluster):
 
     def __repr__(self):
-        return '%s(norb_active= (%d, %d), norb_frozen= (%d, %d))' % (self.__class__.__name__,
-                *self.norb_active, *self.norb_frozen)
+        return '%s(norb_active= (%d, %d), norb_frozen= (%d, %d))' % (
+                self.__class__.__name__, *self.norb_active, *self.norb_frozen,
+        )
 
     # Indices and slices
 
@@ -171,10 +174,10 @@ class ClusterUHF(Cluster):
                 list(range(self.nocc_frozen[1], self.nocc_frozen[1]+self.norb_active[1])))
 
     def get_frozen_indices(self):
-        return (list(range(self.nocc_frozen[0]))
-              + list(range(self.norb_total[0]-self.nvir_frozen[0], self.norb_total[0])),
-                list(range(self.nocc_frozen[1]))
-              + list(range(self.norb_total[1]-self.nvir_frozen[1], self.norb_total[1])))
+        return (
+            list(range(self.nocc_frozen[0])) + list(range(self.norb_total[0]-self.nvir_frozen[0], self.norb_total[0])),
+            list(range(self.nocc_frozen[1])) + list(range(self.norb_total[1]-self.nvir_frozen[1], self.norb_total[1])),
+        )
 
     def repr_size(self):
         lines = []
@@ -182,8 +185,8 @@ class ClusterUHF(Cluster):
         lines += [(fmt % ("Active", "Frozen", "Total")).rstrip()]
         lines += [fmt % (22*'-', 22*'-', 12*'-')]
         fmt = '  %-8s' + 2*'   %5d, %5d (%6.1f%%)' + '   %5d, %5d'
-        get_values = lambda a, f, n : (a[0], a[1], 100*(a[0]+a[1])/(n[0]+n[1]),
-                                       f[0], f[1], 100*(f[0]+f[1])/(n[0]+n[1]), n[0], n[1])
+        get_values = lambda a, f, n: (a[0], a[1], 100*(a[0]+a[1])/(n[0]+n[1]),
+                                      f[0], f[1], 100*(f[0]+f[1])/(n[0]+n[1]), n[0], n[1])
         lines += [fmt % ("Occupied", *get_values(self.nocc_active, self.nocc_frozen, self.nocc_total))]
         lines += [fmt % ("Virtual",  *get_values(self.nvir_active, self.nvir_frozen, self.nvir_total))]
         lines += [fmt % ("Total",    *get_values(self.norb_active, self.norb_frozen, self.norb_total))]

--- a/vayesta/core/types/orbitals.py
+++ b/vayesta/core/types/orbitals.py
@@ -1,12 +1,11 @@
 import numpy as np
 
-import vayesta
-from vayesta.core.util import *
 from vayesta.core.helper import pack_arrays, unpack_arrays
 
 __all__ = [
         'Orbitals', 'SpatialOrbitals', 'SpinOrbitals', 'GeneralOrbitals',
-        ]
+]
+
 
 class MolecularOrbitals:
     """Abstract base class"""
@@ -27,13 +26,17 @@ class MolecularOrbitals:
             if isinstance(x, np.ndarray):
                 return x.copy()
             raise ValueError
-        return type(self)(coeff=_copy(self.coeff), energy=_copy(self.energy), occ=_copy(self.occ),
-                labels=_copy(self.labels), maxocc=_copy(self.maxocc))
+        return type(self)(
+                coeff=_copy(self.coeff), energy=_copy(self.energy), occ=_copy(self.occ),
+                labels=_copy(self.labels), maxocc=_copy(self.maxocc),
+        )
+
 
 def Orbitals(coeff, *args, **kwargs):
     if np.ndim(coeff[0]) == 2:
         return SpinOrbitals(coeff, *args, **kwargs)
     return SpatialOrbitals(coeff, *args, **kwargs)
+
 
 class SpatialOrbitals(MolecularOrbitals):
 
@@ -113,10 +116,14 @@ class SpatialOrbitals(MolecularOrbitals):
 class SpinOrbitals(MolecularOrbitals):
 
     def __init__(self, coeff, energy=None, occ=None, labels=None, maxocc=1):
-        if energy is None: energy = (None, None)
-        if occ is None: occ = (None, None)
-        if labels is None: labels = (None, None)
-        if np.isscalar(maxocc): maxocc = (maxocc, maxocc)
+        if energy is None:
+            energy = (None, None)
+        if occ is None:
+            occ = (None, None)
+        if labels is None:
+            labels = (None, None)
+        if np.isscalar(maxocc):
+            maxocc = (maxocc, maxocc)
         self.alpha = SpatialOrbitals(coeff[0], energy=energy[0], occ=occ[0], labels=labels[0], maxocc=maxocc[0])
         self.beta = SpatialOrbitals(coeff[1], energy=energy[1], occ=occ[1], labels=labels[1], maxocc=maxocc[1])
 
@@ -159,8 +166,10 @@ class SpinOrbitals(MolecularOrbitals):
         return 2
 
     def __getattr__(self, name):
-        if name in ('norb', 'nocc', 'nvir', 'nelec', 'energy',
-                'coeff', 'coeff_occ', 'coeff_vir', 'occ', 'labels', 'maxocc'):
+        if name in (
+                'norb', 'nocc', 'nvir', 'nelec', 'energy',
+                'coeff', 'coeff_occ', 'coeff_vir', 'occ', 'labels', 'maxocc',
+        ):
             return (getattr(self.alpha, name), getattr(self.beta, name))
         raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
 
@@ -211,6 +220,7 @@ class GeneralOrbitals(SpatialOrbitals):
     @classmethod
     def from_spin_orbitals(cls, orbitals):
         raise NotImplementedError
+
 
 if __name__ == '__main__':
 

--- a/vayesta/core/vlog.py
+++ b/vayesta/core/vlog.py
@@ -1,7 +1,6 @@
 """Vayesta logging module"""
 
 import logging
-import os
 import contextlib
 
 from vayesta.mpi import mpi
@@ -26,21 +25,22 @@ TRACE   (*)      1  (-vvv)      To trace function flow
 """
 
 LVL_PREFIX = {
-   "FATAL" : "FATAL",
-   "CRITICAL" : "CRITICAL",
-   "ERROR" : "ERROR",
-   "WARNING" : "WARNING",
-   "OUT" : "OUTPUT",
-   "DEBUGV" : "DEBUG",
-   "TRACE" : "TRACE",
-   }
+       "FATAL": "FATAL",
+       "CRITICAL": "CRITICAL",
+       "ERROR": "ERROR",
+       "WARNING": "WARNING",
+       "OUT": "OUTPUT",
+       "DEBUGV": "DEBUG",
+       "TRACE": "TRACE",
+}
 
 
 class NoLogger:
 
     def __getattr__(self, key):
         """Return function which does nothing."""
-        return (lambda *args, **kwargs : None)
+        return (lambda *args, **kwargs: None)
+
 
 class LevelRangeFilter(logging.Filter):
     """Only log events with level in interval [low, high)."""
@@ -57,6 +57,7 @@ class LevelRangeFilter(logging.Filter):
             return (self._low <= record.levelno)
         return (self._low <= record.levelno < self._high)
 
+
 class LevelIncludeFilter(logging.Filter):
     """Only log events with level in include."""
 
@@ -66,6 +67,7 @@ class LevelIncludeFilter(logging.Filter):
 
     def filter(self, record):
         return (record.levelno in self._include)
+
 
 class LevelExcludeFilter(logging.Filter):
     """Only log events with level not in exlude."""
@@ -77,12 +79,13 @@ class LevelExcludeFilter(logging.Filter):
     def filter(self, record):
         return (record.levelno not in self._exclude)
 
+
 class VFormatter(logging.Formatter):
     """Formatter which adds a prefix column and indentation."""
 
     def __init__(self, *args,
-            show_level=True, show_mpi_rank=False, prefix_sep='|',
-            indent=False, indent_char=' ', indent_width=4, **kwargs):
+                 show_level=True, show_mpi_rank=False, prefix_sep='|',
+                 indent=False, indent_char=' ', indent_width=4, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.show_level = show_level
@@ -117,6 +120,7 @@ class VFormatter(logging.Formatter):
             lines = [((prefix + "  " + line) if line else prefix) for line in lines]
         return "\n".join(lines)
 
+
 class VStreamHandler(logging.StreamHandler):
     """Default stream handler with IndentedFormatter"""
 
@@ -125,6 +129,7 @@ class VStreamHandler(logging.StreamHandler):
         if formatter is None:
             formatter = VFormatter()
         self.setFormatter(formatter)
+
 
 class VFileHandler(logging.FileHandler):
     """Default file handler with IndentedFormatter"""
@@ -136,12 +141,14 @@ class VFileHandler(logging.FileHandler):
             formatter = VFormatter()
         self.setFormatter(formatter)
 
+
 def get_logname(name, add_mpi_rank=True, ext='txt'):
     if mpi and add_mpi_rank:
         name = '%s.mpi%d' % (name, mpi.rank)
     if ext and not name.endswith('.%s' % ext):
         name = '%s.%s' % (name, ext)
     return name
+
 
 def init_logging():
     """Call this to initialize and configure logging, when importing Vayesta.
@@ -158,13 +165,17 @@ def init_logging():
     def add_log_level(level, name):
         logging.addLevelName(level, name.upper())
         setattr(logging, name.upper(), level)
+
         def logForLevel(self, message, *args, **kwargs):
             if self.isEnabledFor(level):
                 self._log(level, message, args, **kwargs)
+
         def logToRoot(message, *args, **kwargs):
             logging.log(level, message, *args, **kwargs)
+
         setattr(logging.getLoggerClass(), name, logForLevel)
         setattr(logging, name, logToRoot)
+
     add_log_level(100, "fatal")
     add_log_level(25, "output")
     add_log_level(15, "infov")

--- a/vayesta/df/df.py
+++ b/vayesta/df/df.py
@@ -8,6 +8,7 @@ import pyscf
 import pyscf.pbc
 import pyscf.pbc.tools
 
+
 # pyscf
 def create_cderi(fname):
     import pyscf.pbc.gto
@@ -49,6 +50,7 @@ def create_cderi(fname):
 
     return cell, gdf, mf
 
+
 def explore(group):
     for key in group.keys():
         print("Key = %s" % key)
@@ -61,7 +63,7 @@ def explore(group):
 def show_hdf5(fname):
     import h5py
     with h5py.File(filename, "r") as f:
-    	# List all groups
+        # List all groups
         explore(f)
         #for key in f.keys():
         #    print("Key = %s" % key)
@@ -71,12 +73,14 @@ def show_hdf5(fname):
         # print values
         print(f['j3c/0/0'][:])
 
+
 libdf = vayesta.libs.load_library('df')
 
 filename = 'bla'
 cell, gdf, mf = create_cderi(filename)
 
 #show_hdf5(filename)
+
 
 def get_jk(mf, gdf, mo_coeff, filename=None, blksize=None, exxdiv=None):
     cell = gdf.cell
@@ -107,7 +111,7 @@ def get_jk(mf, gdf, mo_coeff, filename=None, blksize=None, exxdiv=None):
             ctypes.c_int64(blksize),
             vj.ctypes.data_as(ctypes.c_void_p),
             vk.ctypes.data_as(ctypes.c_void_p),
-            )
+    )
     assert (ierr == 0)
 
     if exxdiv == 'ewald':
@@ -118,6 +122,7 @@ def get_jk(mf, gdf, mo_coeff, filename=None, blksize=None, exxdiv=None):
         vk += madelung * np.linalg.multi_dot((s, dm1, s))
 
     return vj, vk
+
 
 t0 = timer()
 j, k = get_jk(mf, gdf, mf.mo_coeff)

--- a/vayesta/dmet/dmet.py
+++ b/vayesta/dmet/dmet.py
@@ -6,7 +6,7 @@ import scipy
 import scipy.linalg
 
 from vayesta.core.qemb import Embedding
-from vayesta.core.util import *
+from vayesta.core.util import break_into_lines, time_string
 from .fragment import DMETFragment, DMETFragmentExit
 
 from .sdp_sc import perform_SDP_fit
@@ -28,14 +28,18 @@ class Options(Embedding.Options):
     mixing_variable: str = "hl rdm"
     oneshot: bool = False
     # --- Solver options
-    solver_options: dict = Embedding.Options.change_dict_defaults('solver_options',
+    solver_options: dict = Embedding.Options.change_dict_defaults(
+            'solver_options',
             # CCSD
-            solve_lambda=True)
+            solve_lambda=True,
+    )
+
 
 @dataclasses.dataclass
 class DMETResults:
     cluster_sizes: np.ndarray = None
     e_corr: float = None
+
 
 class DMET(Embedding):
 
@@ -178,8 +182,12 @@ class DMET(Embedding):
                         break
                 # If we've got to here we've found a bracket.
                 [lo, hi] = sorted([cpt, new_cpt])
-                cpt, res = scipy.optimize.brentq(electron_err, a=lo, b=hi, full_output=True,
-                                                 xtol=self.opts.max_elec_err * nelec_mf)  # self.opts.max_elec_err * nelec_mf)
+                cpt, res = scipy.optimize.brentq(
+                        electron_err,
+                        a=lo,
+                        b=hi,
+                        full_output=True,
+                        xtol=self.opts.max_elec_err * nelec_mf)  # self.opts.max_elec_err * nelec_mf)
                 self.log.info("Converged chemical potential: {:6.4e}".format(cpt))
                 # Recalculate to ensure all fragments have up-to-date info. Brentq strangely seems to do an extra
                 # calculation at the end...
@@ -283,5 +291,6 @@ class DMET(Embedding):
         self.log.info("%3s  %20s  %8s  %4s", "ID", "Name", "Solver", "Size")
         for frag in self.loop():
             self.log.info("%3d  %20s  %8s  %4d", frag.id, frag.name, frag.solver, frag.size)
+
 
 RDMET = DMET

--- a/vayesta/dmet/fragment.py
+++ b/vayesta/dmet/fragment.py
@@ -1,19 +1,18 @@
 import dataclasses
-from timeit import default_timer as timer
 
 # External libaries
 import numpy as np
 
 from vayesta.core.qemb import Fragment
-from vayesta.core.bath import BNO_Threshold
 from vayesta.solver import get_solver_class
-from vayesta.core.util import *
+from vayesta.core.util import log_time, dot
 
 
 # We might want to move the useful things from here into core, since they seem pretty general.
 
 class DMETFragmentExit(Exception):
     pass
+
 
 @dataclasses.dataclass
 class Results(Fragment.Results):
@@ -22,6 +21,7 @@ class Results(Fragment.Results):
     e2: float = None
     dm1: np.ndarray = None
     dm2: np.ndarray = None
+
 
 class DMETFragment(Fragment):
 
@@ -81,8 +81,10 @@ class DMETFragment(Fragment):
         with log_time(self.log.info, ("Time for %s solver:" % solver) + " %s"):
             cluster_solver.kernel(eris=eris)
 
-        self._results = results = self.Results(fid=self.id, wf=cluster_solver.wf, n_active=self.cluster.norb_active,
-                dm1=cluster_solver.wf.make_rdm1(), dm2=cluster_solver.wf.make_rdm2())
+        self._results = results = self.Results(
+                fid=self.id, wf=cluster_solver.wf, n_active=self.cluster.norb_active,
+                dm1=cluster_solver.wf.make_rdm1(), dm2=cluster_solver.wf.make_rdm2(),
+        )
         results.e1, results.e2 = self.get_dmet_energy_contrib()
 
         return results

--- a/vayesta/dmet/pdmet.py
+++ b/vayesta/dmet/pdmet.py
@@ -7,6 +7,7 @@ import scipy.linalg
 
 log = logging.getLogger(__name__)
 
+
 def update_mf(mf, dm1, canonicalize=True, inplace=False, damping=0.0, diis=None):
     """p-DMET mean-field update."""
 

--- a/vayesta/dmet/sdp_sc.py
+++ b/vayesta/dmet/sdp_sc.py
@@ -65,9 +65,9 @@ def perform_SDP_fit(nelec, fock, impurity_projectors, target_rdms, ovlp, log):
     )
     prob = cp.Problem(objective, constraints)
 
-    solval = prob.solve(solver=cp.SCS, eps=1e-8)
+    prob.solve(solver=cp.SCS, eps=1e-8)
     msg = "SDP fitting completed. Status= %s" % prob.status
-    if not prob.status in [cp.OPTIMAL]:  # , cp.OPTIMAL_INACCURATE]:
+    if prob.status not in [cp.OPTIMAL]:  # , cp.OPTIMAL_INACCURATE]:
         log.warning(msg)
     else:
         log.info(msg)

--- a/vayesta/dmet/udmet.py
+++ b/vayesta/dmet/udmet.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from vayesta.core.qemb import UEmbedding
-from vayesta.core.util import *
 
 from vayesta.dmet import RDMET
 from vayesta.dmet.ufragment import UDMETFragment as Fragment
@@ -17,7 +16,7 @@ class UDMET(UEmbedding, RDMET):
         self.log.info("Now running DMET correlation potential fitting")
         # Note that we want the total number of electrons, not just in fragments, and that this uses spatial orbitals.
         vcorr_new = np.array((perform_SDP_fit(self.mol.nelec[0], fock[0], impurity_coeffs[0], [x[0] for x in curr_rdms],
-                                             self.get_ovlp(), self.log),
+                                              self.get_ovlp(), self.log),
                              perform_SDP_fit(self.mol.nelec[1], fock[1], impurity_coeffs[1], [x[1] for x in curr_rdms],
                                              self.get_ovlp(), self.log)))
 

--- a/vayesta/dmet/updates.py
+++ b/vayesta/dmet/updates.py
@@ -25,7 +25,6 @@ class Update:
         return flat_params
 
     def _unflatten_params(self, params):
-        res = []
         x = 0
 
         def get_nonflat(flat_params, shapes, x):

--- a/vayesta/edmet/edmet.py
+++ b/vayesta/edmet/edmet.py
@@ -5,12 +5,12 @@ import numpy as np
 import scipy
 import scipy.linalg
 
-from vayesta.core.util import *
+from vayesta.core.util import dot, time_string
 from vayesta.dmet import RDMET
-from vayesta.dmet.sdp_sc import perform_SDP_fit
 from vayesta.dmet.updates import MixUpdate, DIISUpdate
 from vayesta.rpa import ssRPA, ssRIRPA
 from .fragment import EDMETFragment, EDMETFragmentExit
+
 
 @dataclasses.dataclass
 class Options(RDMET.Options):
@@ -22,10 +22,12 @@ class Options(RDMET.Options):
     boson_xc_kernel: bool = False
     bosonic_interaction: str = "xc"
 
+
 @dataclasses.dataclass
 class EDMETResults:
     cluster_sizes: np.ndarray = None
     e_corr: float = None
+
 
 class EDMET(RDMET):
 
@@ -264,9 +266,9 @@ class EDMET(RDMET):
                                     construct_bath=True):
         self.log.info("Running chemical potential={:8.6e}".format(chempot))
         # Save original one-body hamiltonian calculation.
-        saved_hcore = self.mf.get_hcore
+        #saved_hcore = self.mf.get_hcore
 
-        hl_rdms = [None] * len(parent_fragments)
+        #hl_rdms = [None] * len(parent_fragments)
         hl_dd0 = [None] * len(parent_fragments)
         hl_dd1 = [None] * len(parent_fragments)
         nelec_hl = 0.0
@@ -350,7 +352,7 @@ class EDMET(RDMET):
             if xc_kernel.lower() == "drpa":
                 xc = None
             else:
-                raise ValueError("Unknown xc kernel %s provided".format(xc_kernel))
+                raise ValueError("Unknown xc kernel %s provided" % xc_kernel)
         elif xc_kernel is None:
             xc = self.xc_kernel
         elif isinstance(xc_kernel, tuple) or isinstance(xc_kernel, np.ndarray):
@@ -361,11 +363,15 @@ class EDMET(RDMET):
         if self.with_df:
             # Set up for RIRPA zeroth moment calculation.
             rpa = ssRIRPA(self.mf, xc, self.log)
-            local_rot = [np.concatenate([x.get_rot_to_mf_ov(), x.r_bos], axis=0) for x in self.fragments] if calc_local else None
+            if calc_local:
+                local_rot = [np.concatenate([x.get_rot_to_mf_ov(), x.r_bos], axis=0) for x in self.fragments]
+            else:
+                local_rot = None
             frag_proj = [x.get_fragment_projector_ov() for x in self.fragments] if calc_local else None
             return rpa.direct_AC_integration(local_rot, frag_proj, deg=deg, npoints=npoints,
                                              cluster_constrain=cluster_constrain)
         else:
             raise NotImplementedError
+
 
 REDMET = EDMET

--- a/vayesta/edmet/uedmet.py
+++ b/vayesta/edmet/uedmet.py
@@ -1,8 +1,5 @@
 import numpy as np
 
-from vayesta.core.qemb import UEmbedding
-from vayesta.core.util import *
-
 from vayesta.dmet import UDMET
 from vayesta.edmet import REDMET
 from vayesta.edmet.ufragment import UEDMETFragment as Fragment

--- a/vayesta/edmet/ufragment.py
+++ b/vayesta/edmet/ufragment.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyscf.lib
 
-from vayesta.core.util import *
+from vayesta.core.util import dot, einsum
 from vayesta.dmet.ufragment import UDMETFragment
 from .fragment import EDMETFragment
 
@@ -118,8 +118,10 @@ class UEDMETFragment(UDMETFragment, EDMETFragment):
     def conv_to_aos(self, ra, rb):
         ra = ra.reshape((-1, self.base.nocc[0], self.base.nvir[0]))
         rb = rb.reshape((-1, self.base.nocc[1], self.base.nvir[1]))
-        return einsum("nia,pi,qa->npq", ra, self.base.mo_coeff_occ[0], self.base.mo_coeff_vir[0]), \
-               einsum("nia,pi,qa->npq", rb, self.base.mo_coeff_occ[1], self.base.mo_coeff_vir[1])
+        return (
+            einsum("nia,pi,qa->npq", ra, self.base.mo_coeff_occ[0], self.base.mo_coeff_vir[0]),
+            einsum("nia,pi,qa->npq", rb, self.base.mo_coeff_occ[1], self.base.mo_coeff_vir[1])
+        )
 
     def get_eri_couplings(self, rot):
         """Obtain eri in a space defined by an arbitrary rotation of the mean-field particle-hole excitations of our
@@ -153,8 +155,10 @@ class UEDMETFragment(UDMETFragment, EDMETFragment):
             eris_bb = eris_bb[:self.base.nocc[1], self.base.nocc[1]:, :self.base.nocc[1], self.base.nocc[1]:].reshape(
                 (self.ov_mf[1], self.ov_mf[1]))
 
-            return dot(rota, eris_aa, rota.T) + dot(rota, eris_ab, rotb.T) + \
-                   dot(rotb, eris_ab.T, rota.T) + dot(rotb, eris_bb, rotb.T)
+            return (
+                + dot(rota, eris_aa, rota.T) + dot(rota, eris_ab, rotb.T)
+                + dot(rotb, eris_ab.T, rota.T) + dot(rotb, eris_bb, rotb.T)
+            )
 
     def get_rbos_split(self):
         r_bos_a = self.r_bos[:, :self.ov_mf[0]]

--- a/vayesta/ewf/amplitudes.py
+++ b/vayesta/ewf/amplitudes.py
@@ -1,8 +1,6 @@
-import functools
-
 import numpy as np
 
-from vayesta.core.util import *
+from vayesta.core.util import dot, einsum, NotCalculatedError
 from vayesta.mpi import mpi
 
 
@@ -45,6 +43,7 @@ def get_global_t1_rhf(emb, get_lambda=False, mpi_target=None, ao_basis=False):
         t1 = dot(emb.mo_coeff_occ, t1, emb.mo_coeff_vir.T)
     return t1
 
+
 def get_global_t2_rhf(emb, get_lambda=False, symmetrize=True, mpi_target=None, ao_basis=False):
     """Get global CCSD T2 amplitudes from fragment calculations.
 
@@ -79,8 +78,12 @@ def get_global_t2_rhf(emb, get_lambda=False, symmetrize=True, mpi_target=None, a
     if mpi:
         t2 = mpi.nreduce(t2, target=mpi_target, logfunc=emb.log.timingv)
     if ao_basis:
-        t2 = einsum('Ii,Jj,ijab,Aa,Bb->IJAB', emb.mo_coeff_occ, emb.mo_coeff_occ, t2, emb.mo_coeff_vir, emb.mo_coeff_vir)
+        t2 = einsum(
+                'Ii,Jj,ijab,Aa,Bb->IJAB',
+                emb.mo_coeff_occ, emb.mo_coeff_occ, t2, emb.mo_coeff_vir, emb.mo_coeff_vir,
+        )
     return t2
+
 
 def get_global_t1_uhf(emb, get_lambda=False, mpi_target=None, ao_basis=False):
     """Get global CCSD T1 from fragment calculations.
@@ -119,6 +122,7 @@ def get_global_t1_uhf(emb, get_lambda=False, mpi_target=None, ao_basis=False):
         t1a = dot(emb.mo_coeff_occ[0], t1a, emb.mo_coeff_vir[0].T)
         t1b = dot(emb.mo_coeff_occ[1], t1b, emb.mo_coeff_vir[1].T)
     return (t1a, t1b)
+
 
 def get_global_t2_uhf(emb, get_lambda=False, symmetrize=True, mpi_target=None, ao_basis=False):
     """Get global CCSD T2 amplitudes from fragment calculations.

--- a/vayesta/ewf/helper.py
+++ b/vayesta/ewf/helper.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy as np
 
-from vayesta.core.util import *
+from vayesta.core.util import einsum
 
 log = logging.getLogger(__name__)
 

--- a/vayesta/ewf/urdm.py
+++ b/vayesta/ewf/urdm.py
@@ -5,11 +5,20 @@ import numpy as np
 import pyscf
 import pyscf.cc
 
-from vayesta.core.util import *
+from vayesta.core.util import dot, einsum, Object
 from vayesta.mpi import mpi
 
 
-def make_rdm1_ccsd(emb, ao_basis=False, t_as_lambda=False, symmetrize=True, with_mf=True, mpi_target=None, mp2=False, ba_order='ba'):
+def make_rdm1_ccsd(
+        emb,
+        ao_basis=False,
+        t_as_lambda=False,
+        symmetrize=True,
+        with_mf=True,
+        mpi_target=None,
+        mp2=False,
+        ba_order='ba',
+):
     """Make one-particle reduced density-matrix from partitioned fragment CCSD wave functions.
 
     MPI parallelized.
@@ -77,8 +86,8 @@ def make_rdm1_ccsd(emb, ao_basis=False, t_as_lambda=False, symmetrize=True, with
         # aa/bb - > dvva/dvvb
         dvva += einsum('ijac,ijbc,Aa,Bb->AB', t2xaa, l2xaa, cva, cva) / 2
         dvvb += einsum('ijac,ijbc,Aa,Bb->AB', t2xbb, l2xbb, cvb, cvb) / 2
-        # We cannot symmetrize the ba/ab -> dooa/doob part between t/l2xab and t/l2xba (and keep a single fragment loop);
-        # instead dooa only uses the "ba" amplitudes and doob only the "ab" amplitudes.
+        # We cannot symmetrize the ba/ab -> dooa/doob part between t/l2xab and t/l2xba (and keep a
+        # single fragment loop); instead dooa only uses the "ba" amplitudes and doob only the "ab" amplitudes.
         # In order to ensure the correct number of alpha and beta electrons, we should use the same choice for the
         # virtual-virtual parts (even though here we could symmetrize them as:
         #dvva += einsum('ijac,ijbc,Aa,Bb->AB', t2xba, l2xba, cva, cva) / 2
@@ -169,8 +178,20 @@ def make_rdm1_ccsd(emb, ao_basis=False, t_as_lambda=False, symmetrize=True, with
 
     return (dm1a, dm1b)
 
-def make_rdm1_ccsd_global_wf(emb, ao_basis=False, with_mf=True, t_as_lambda=False, with_t1=True,
-        svd_tol=1e-3, ovlp_tol=None, use_sym=True, late_t2_sym=True, mpi_target=None, slow=True):
+
+def make_rdm1_ccsd_global_wf(
+        emb,
+        ao_basis=False,
+        with_mf=True,
+        t_as_lambda=False,
+        with_t1=True,
+        svd_tol=1e-3,
+        ovlp_tol=None,
+        use_sym=True,
+        late_t2_sym=True,
+        mpi_target=None,
+        slow=True,
+):
     """Make one-particle reduced density-matrix from partitioned fragment CCSD wave functions.
 
     NOT MPI READY
@@ -213,6 +234,7 @@ def make_rdm1_ccsd_global_wf(emb, ao_basis=False, with_mf=True, t_as_lambda=Fals
     # TODO
     raise NotImplementedError
 
+
 def make_rdm2_ccsd_global_wf(emb, ao_basis=False, symmetrize=False, t_as_lambda=False, slow=True, with_dm1=True):
     """Recreate global two-particle reduced density-matrix from fragment calculations.
 
@@ -254,6 +276,7 @@ def make_rdm2_ccsd_global_wf(emb, ao_basis=False, symmetrize=False, t_as_lambda=
         #dm2 = (dm2 + dm2.transpose(1,0,3,2))/2
     return dm2
 
+
 def make_rdm2_ccsd_proj_lambda(emb, ao_basis=False, t_as_lambda=False, with_dm1=True, mpi_target=None):
     """Make two-particle reduced density-matrix from partitioned fragment CCSD wave functions.
 
@@ -283,7 +306,7 @@ def make_rdm2_ccsd_proj_lambda(emb, ao_basis=False, t_as_lambda=False, with_dm1=
     dm2aa = np.zeros(4*[nmoa])
     dm2ab = np.zeros(2*[nmoa]+2*[nmob])
     dm2bb = np.zeros(4*[nmob])
-    ovlp = emb.get_ovlp()
+    #ovlp = emb.get_ovlp()
     for x in emb.get_fragments(active=True, mpi_rank=mpi.rank):
         dm2xaa, dm2xab, dm2xbb = x.make_fragment_dm2cumulant(t_as_lambda=t_as_lambda)
         ra, rb =  x.get_overlap('mo|cluster')

--- a/vayesta/lattmod/bethe.py
+++ b/vayesta/lattmod/bethe.py
@@ -22,6 +22,7 @@ def hubbard1d_bethe_energy(t, u, interval=(1e-14, 30.75*np.pi), **kwargs):
 
     return e
 
+
 def hubbard1d_bethe_docc(t, u, interval=(1e-14, 30.75*np.pi), **kwargs):
     """Exact on-site double occupancy for the 1D Hubbard model in the thermodynamic limit."""
 
@@ -53,15 +54,16 @@ def hubbard1d_bethe_docc_numdiff(t, u, du=1e-10, order=2, **kwargs):
         ep1 = hubbard1d_bethe_energy(t, u+du, **kwargs)
         docc = (1/2*ep1 - 1/2*em1) / du
     elif order == 2:
-        em2 = hubbard1d_bethe_energy(t, u-2*du, **kwargs)
-        em1 = hubbard1d_bethe_energy(t, u-  du, **kwargs)
-        ep1 = hubbard1d_bethe_energy(t, u+  du, **kwargs)
-        ep2 = hubbard1d_bethe_energy(t, u+2*du, **kwargs)
+        em2 = hubbard1d_bethe_energy(t, u - 2 * du, **kwargs)
+        em1 = hubbard1d_bethe_energy(t, u -     du, **kwargs)
+        ep1 = hubbard1d_bethe_energy(t, u +     du, **kwargs)
+        ep2 = hubbard1d_bethe_energy(t, u + 2 * du, **kwargs)
         docc = (1/12*em2 - 2/3*em1 + 2/3*ep1 - 1/12*ep2) / du
     else:
         raise NotImplementedError()
 
     return docc
+
 
 if __name__ == '__main__':
     t = 1.0

--- a/vayesta/misc/brueckner.py
+++ b/vayesta/misc/brueckner.py
@@ -7,6 +7,7 @@ import scipy.linalg
 
 log = logging.getLogger(__name__)
 
+
 def update_mo_coeff(mo_coeff, t1, ovlp=None, damping=0.0, diis=None):
     nocc, nvir = t1.shape
     nmo = mo_coeff.shape[-1]
@@ -47,6 +48,7 @@ def update_mo_coeff(mo_coeff, t1, ovlp=None, damping=0.0, diis=None):
     assert np.allclose(np.linalg.multi_dot((bmo.T, ovlp, bmo))-np.eye(nmo), 0)
     return bmo_occ, bmo_vir
 
+
 def update_mf(mf, t1, mo_coeff=None, inplace=False, canonicalize=True, damping=0.0, diis=None):
     """Update occupied MOs based on T1 amplitudes, to converge to Brueckner MOs.
 
@@ -73,14 +75,16 @@ def update_mf(mf, t1, mo_coeff=None, inplace=False, canonicalize=True, damping=0
     if not inplace:
         mf = copy.copy(mf)
 
-    if mo_coeff is None: mo_coeff = mf.mo_coeff
+    if mo_coeff is None:
+        mo_coeff = mf.mo_coeff
     nmo = mo_coeff.shape[-1]
     nocc = np.count_nonzero(mf.mo_occ > 0)
     nvir = (nmo-nocc)
     assert t1.shape == (nocc, nvir)
 
     ovlp = mf.get_ovlp()
-    if np.allclose(ovlp, np.eye(ovlp.shape[-1])): ovlp = None
+    if np.allclose(ovlp, np.eye(ovlp.shape[-1])):
+        ovlp = None
     bmo_occ, bmo_vir = update_mo_coeff(mo_coeff, t1, ovlp, damping=damping, diis=diis)
     # Diagonalize one-electron Hamiltonian or Fock matrix within occupied and virtual space:
     if canonicalize:

--- a/vayesta/misc/corrfunc.py
+++ b/vayesta/misc/corrfunc.py
@@ -1,7 +1,7 @@
 """Correlation function"""
 
 import numpy as np
-from vayesta.core.util import dot, einsum
+from vayesta.core.util import einsum
 
 
 def _get_proj_per_spin(p):
@@ -10,6 +10,7 @@ def _get_proj_per_spin(p):
     if np.ndim(p[0]) == 1:
         return p, p
     raise ValueError()
+
 
 def chargecharge(dm1, dm2, proj1=None, proj2=None, subtract_indep=True):
     if dm2 is None:
@@ -28,10 +29,12 @@ def chargecharge(dm1, dm2, proj1=None, proj2=None, subtract_indep=True):
         corr -= np.sum(dm1 * proj1) * np.sum(dm1 * proj2)
     return corr
 
+
 # --- Correlated:
 
 def spin_z(dm1, proj=None):
     return 0.0
+
 
 def spin_z_unrestricted(dm1, proj=None):
     dm1a, dm1b = dm1
@@ -40,9 +43,12 @@ def spin_z_unrestricted(dm1, proj=None):
         return sz
 
     pa, pb = _get_proj_per_spin(proj)
-    sz = (einsum('ij,ij->', dm1a, pa)
-        - einsum('ij,ij->', dm1b, pb))/2
+    sz = (
+        + einsum('ij,ij->', dm1a, pa)
+        - einsum('ij,ij->', dm1b, pb)
+    ) / 2
     return sz
+
 
 def spinspin_z(dm1, dm2, proj1=None, proj2=None):
     if dm2 is None:
@@ -57,10 +63,13 @@ def spinspin_z(dm1, dm2, proj1=None, proj2=None):
         ssz = (einsum('iijj->', dm2aa) - einsum('iijj->', dm2ab))/2
         ssz += np.trace(dm1a)/2
         return ssz
-    ssz = (einsum('ijkl,ij,kl->', dm2aa, proj1, proj2)
-         - einsum('ijkl,ij,kl->', dm2ab, proj1, proj2))/2
+    ssz = (
+        + einsum('ijkl,ij,kl->', dm2aa, proj1, proj2)
+        - einsum('ijkl,ij,kl->', dm2ab, proj1, proj2)
+    ) / 2
     ssz += einsum('ij,ik,jk->', dm1a, proj1, proj2)/2
     return ssz
+
 
 def spinspin_z_unrestricted(dm1, dm2, proj1=None, proj2=None):
     if dm2 is None:
@@ -71,19 +80,27 @@ def spinspin_z_unrestricted(dm1, dm2, proj1=None, proj2=None):
     if proj2 is None:
         proj2 = proj1
     if proj1 is None:
-        ssz = (einsum('iijj->', dm2aa)/4 + einsum('iijj->', dm2bb)/4
-             - einsum('iijj->', dm2ab)/2)
-        ssz += (np.trace(dma) + np.trace(dmb))/4
+        ssz = (
+            + einsum('iijj->', dm2aa)/4
+            + einsum('iijj->', dm2bb)/4
+            - einsum('iijj->', dm2ab)/2
+        )
+        ssz += (np.trace(dm1a) + np.trace(dm1b))/4
         return ssz
     p1a, p1b = _get_proj_per_spin(proj1)
     p2a, p2b = _get_proj_per_spin(proj2)
-    ssz = (einsum('ijkl,ij,kl->', dm2aa, p1a, p2a)/4
-         + einsum('ijkl,ij,kl->', dm2bb, p1b, p2b)/4
-         - einsum('ijkl,ij,kl->', dm2ab, p1a, p2b)/4
-         - einsum('ijkl,ij,kl->', dm2ab, p2a, p1b)/4)
-    ssz += (einsum('ij,ik,jk->', dm1a, p1a, p2a)
-          + einsum('ij,ik,jk->', dm1b, p1b, p2b))/4
+    ssz = (
+        + einsum('ijkl,ij,kl->', dm2aa, p1a, p2a)/4
+        + einsum('ijkl,ij,kl->', dm2bb, p1b, p2b)/4
+        - einsum('ijkl,ij,kl->', dm2ab, p1a, p2b)/4
+        - einsum('ijkl,ij,kl->', dm2ab, p2a, p1b)/4
+    )
+    ssz += (
+        + einsum('ij,ik,jk->', dm1a, p1a, p2a)
+        + einsum('ij,ik,jk->', dm1b, p1b, p2b)
+    )/4
     return ssz
+
 
 # --- Mean-field:
 
@@ -102,6 +119,7 @@ def chargecharge_mf(dm1, proj1=None, proj2=None, subtract_indep=True):
     corr -= einsum('(ik,ij),(kl,lj)->', proj1, dm1, dm1, proj2)/2
     corr += einsum('ij,ik,jk->', dm1, proj1, proj2)
     return corr
+
 
 def spinspin_z_mf(dm1, proj1=None, proj2=None):
     # TEMP:
@@ -125,30 +143,37 @@ def spinspin_z_mf(dm1, proj1=None, proj2=None):
     #      + einsum('ij,ik,jk->', dmb, p1b, p2b))/4
     #return ssz
 
+
 def spinspin_z_mf_unrestricted(dm1, proj1=None, proj2=None):
     dma, dmb = dm1
     if proj2 is None:
         proj2 = proj1
     if proj1 is None:
-        ssz = (einsum('ii,jj->', dma, dma)/4
-            -  einsum('ij,ij->', dma, dma)/4
-            +  einsum('ii,jj->', dmb, dmb)/4
-            -  einsum('ij,ij->', dmb, dmb)/4
-            -  einsum('ii,jj->', dma, dmb)/2)
+        ssz = (
+            + einsum('ii,jj->', dma, dma)/4
+            - einsum('ij,ij->', dma, dma)/4
+            + einsum('ii,jj->', dmb, dmb)/4
+            - einsum('ij,ij->', dmb, dmb)/4
+            - einsum('ii,jj->', dma, dmb)/2
+        )
         ssz += (np.trace(dma) + np.trace(dmb))/4
         return ssz
 
     p1a, p1b = (proj1, proj1) if np.ndim(proj1[0]) == 1 else proj1
     p2a, p2b = (proj2, proj2) if np.ndim(proj2[0]) == 1 else proj2
 
-    ssz = (einsum('(ij,ij),(kl,kl)->', p1a, dma, dma, p2a)
-         - einsum('(ij,il),(jk,kl)->', p1a, dma, dma, p2a)
-         + einsum('(ij,ij),(kl,kl)->', p1b, dmb, dmb, p2b)
-         - einsum('(ij,il),(jk,kl)->', p1b, dmb, dmb, p2b)
-         - einsum('(ij,ij),(kl,kl)->', p1a, dma, dmb, p2b)
-         - einsum('(ij,ij),(kl,kl)->', p1b, dmb, dma, p2a))/4
-    ssz += (einsum('ij,ik,jk->', dma, p1a, p2a)
-          + einsum('ij,ik,jk->', dmb, p1b, p2b))/4
+    ssz = (
+        + einsum('(ij,ij),(kl,kl)->', p1a, dma, dma, p2a)
+        - einsum('(ij,il),(jk,kl)->', p1a, dma, dma, p2a)
+        + einsum('(ij,ij),(kl,kl)->', p1b, dmb, dmb, p2b)
+        - einsum('(ij,il),(jk,kl)->', p1b, dmb, dmb, p2b)
+        - einsum('(ij,ij),(kl,kl)->', p1a, dma, dmb, p2b)
+        - einsum('(ij,ij),(kl,kl)->', p1b, dmb, dma, p2a)
+    )/4
+    ssz += (
+        + einsum('ij,ik,jk->', dma, p1a, p2a)
+        + einsum('ij,ik,jk->', dmb, p1b, p2b)
+    )/4
     return ssz
 
 
@@ -176,12 +201,10 @@ if __name__ == '__main__':
     sz = spin_z(dm1)
     print(sz)
 
-
-    ssz = spinspin_z_rhf(dm1)
+    ssz = spinspin_z_mf(dm1)
     print(ssz)
     1/0
     #print('RHF: <S_z>= %.8f  <S_z S_z>= %.8f' % (sz, ssz))
-
 
     # UHF
     mol.charge = mol.spin = 1
@@ -199,8 +222,8 @@ if __name__ == '__main__':
     dm1b[np.diag_indices(noccb)] = 1
     dm1 = (dm1a, dm1b)
 
-    sz = spin_z_uhf(dm1)
-    print(sz)
+    #sz = spin_z_uhf(dm1)
+    #print(sz)
     sz = spin_z_unrestricted(dm1)
     print(sz)
     #ssz = spinspin_z_uhf(uhf)

--- a/vayesta/misc/counterpoise.py
+++ b/vayesta/misc/counterpoise.py
@@ -112,7 +112,10 @@ def make_cp_mol(mol, atom, rmax, nimages=1, unit='A', **kwargs):
                             symb = 'Ghost-' + symb
                         distance = np.linalg.norm(coord - center)
                         if (not rmax) or (distance <= rmax):
-                            log.debugv("Counterpoise: adding atom %6s at %8.5f %8.5f %8.5f with distance %8.5f A", symb, *coord, distance)
+                            log.debugv(
+                                    "Counterpoise: adding atom %6s at %8.5f %8.5f %8.5f with distance %8.5f A",
+                                    symb, *coord, distance,
+                            )
                             atoms.append((symb, coord))
         log.info("Counterpoise with rmax %.3f A -> %3d ghost atoms", rmax, (len(atoms)-1))
     mol_cp = mol.copy()

--- a/vayesta/misc/cptbisect.py
+++ b/vayesta/misc/cptbisect.py
@@ -1,9 +1,7 @@
-import logging
 import numpy as np
 import scipy
 
 import vayesta
-from vayesta.core.util import *
 
 
 class ChempotBisection:
@@ -41,6 +39,7 @@ class ChempotBisection:
         upper = max(cpt1, cpt3)
 
         it = 1
+
         def iteration(cpt, *args, **kwargs):
             nonlocal it
             if (cpt == cpt1):
@@ -56,7 +55,7 @@ class ChempotBisection:
                 raise StopIteration
             return err
         try:
-            res = scipy.optimize.brentq(iteration, lower, upper)
+            scipy.optimize.brentq(iteration, lower, upper)
         except StopIteration:
             self.converged = True
         return self.cpt

--- a/vayesta/misc/cubefile.py
+++ b/vayesta/misc/cubefile.py
@@ -18,9 +18,17 @@ log = logging.getLogger(__name__)
 
 class CubeFile:
 
-    def __init__(self, cell, filename=None, gridsize=(100, 100, 100), resolution=None,
-            title=None, comment=None, fmt="%13.5E",
-            crop=None):
+    def __init__(
+            self,
+            cell,
+            filename=None,
+            gridsize=(100, 100, 100),
+            resolution=None,
+            title=None,
+            comment=None,
+            fmt="%13.5E",
+            crop=None,
+    ):
         """Initialize a cube file object. Data can be added using the `add_orbital` and `add_density` methods.
 
         This class can also be used as a context manager:
@@ -157,8 +165,9 @@ class CubeFile:
             be labelled as 'Orbital <dset_idx>' or similar. If set to `None`,
             the smallest unused, positive integer will be used. Default: None.
         """
-        coeff = np.array(coeff) # Force copy
-        if coeff.ndim == 1: coeff = coeff[:,np.newaxis]
+        coeff = np.array(coeff)  # Force copy
+        if coeff.ndim == 1:
+            coeff = coeff[:,np.newaxis]
         assert (coeff.ndim == 2)
         for i, c in enumerate(coeff.T):
             idx = dset_idx+i if dset_idx is not None else None
@@ -179,7 +188,8 @@ class CubeFile:
             the smallest unused, positive integer will be used. Default: None.
         """
         dm = np.array(dm)   # Force copy
-        if dm.ndim == 2: dm = dm[np.newaxis]
+        if dm.ndim == 2:
+            dm = dm[np.newaxis]
         assert (dm.ndim == 3)
         for i, d in enumerate(dm):
             idx = dset_idx+i if dset_idx is not None else None
@@ -260,6 +270,7 @@ class CubeFile:
                 for d0, d1 in pyscf.lib.prange(0, len(data), 6):
                     f.write(((d1-d0)*self.fmt + '\n') % tuple(data[d0:d1]))
 
+
 if __name__ == '__main__':
 
     def make_graphene(a, c, atoms=["C", "C"], supercell=None):
@@ -288,19 +299,18 @@ if __name__ == '__main__':
             amat = np.einsum('i,ij->ij', ncopy, amat)
         return amat, atom
 
-
     from pyscf import pbc
     cell = pbc.gto.Cell(
-        basis = 'gth-dzv',
-        pseudo = 'gth-pade',
-        dimension = 2,
+        basis='gth-dzv',
+        pseudo='gth-pade',
+        dimension=2,
         verbose=10)
     cell.a, cell.atom = make_graphene(2.46, 10.0, supercell=(2,2,1))
     hf = pbc.scf.HF(cell)
     hf = hf.density_fit()
     hf.kernel()
 
-    with CubeFile(cell, "graphene.cube", crop={"c0" : 5.0, "c1" : 5.0}) as f:
+    with CubeFile(cell, "graphene.cube", crop={"c0": 5.0, "c1": 5.0}) as f:
         f.add_orbital(hf.mo_coeff[:,0])
         f.add_orbital(hf.mo_coeff[:,6:10])
         f.add_density([hf.make_rdm1(), np.linalg.inv(hf.get_ovlp())-hf.make_rdm1()])

--- a/vayesta/misc/gdf.py
+++ b/vayesta/misc/gdf.py
@@ -451,8 +451,10 @@ def _cholesky_decomposed_metric(with_df, j2c, uniq_kptji_id, log=None):
     if not with_df.linear_dep_always:
         try:
             j2c_kpt = scipy.linalg.cholesky(j2c[uniq_kptji_id], lower=True)
+
             def j2c_chol(x):
                 return scipy.linalg.solve_triangular(j2c_kpt, x, lower=True, overwrite_b=True)
+
         except scipy.linalg.LinAlgError:
             log.warning("Cholesky decomposition failed for j2c [kpt %d]", uniq_kptji_id)
             pass
@@ -461,8 +463,10 @@ def _cholesky_decomposed_metric(with_df, j2c, uniq_kptji_id, log=None):
         try:
             eps = 1e-14 * np.eye(j2c[uniq_kptji_id].shape[-1])
             j2c_kpt = scipy.linalg.cholesky(j2c[uniq_kptji_id] + eps, lower=True)
+
             def j2c_chol(x):
                 return scipy.linalg.solve_triangular(j2c_kpt, x, lower=True, overwrite_b=True)
+
         except scipy.linalg.LinAlgError:
             log.warning("Regularised Cholesky decomposition failed for j2c [kpt %d]", uniq_kptji_id)
             pass
@@ -478,6 +482,7 @@ def _cholesky_decomposed_metric(with_df, j2c, uniq_kptji_id, log=None):
 
         j2c_kpt = v[:, mask].conj().T
         j2c_kpt /= np.sqrt(w[mask])[:, None]
+
         def j2c_chol(x):
             return np.dot(j2c_kpt, x)
 
@@ -606,7 +611,7 @@ def _make_j3c(with_df, kptij_lst):
     kptjs = kptij_lst[:, 1]
     kpt_ji = kptjs - kptis
     uniq_kpts, uniq_index, uniq_inverse = unique(kpt_ji)
-    uniq_inverse_dict = { k: np.where(uniq_inverse == k)[0] for k in range(len(uniq_kpts)) }
+    uniq_inverse_dict = {k: np.where(uniq_inverse == k)[0] for k in range(len(uniq_kpts))}
 
     log.info("Number of unique kpts (kj - ki): %d", len(uniq_kpts))
     log.debugv("uniq_kpts:\n%s", uniq_kpts)
@@ -908,10 +913,8 @@ class GDF(df.GDF):
                     dms[i].ctypes.data_as(ctypes.c_void_p),
                     ctypes.c_bool(with_j),
                     ctypes.c_bool(with_k),
-                    vj[i].ctypes.data_as(ctypes.c_void_p) if vj is not None
-                                      else ctypes.POINTER(ctypes.c_void_p)(),
-                    vk[i].ctypes.data_as(ctypes.c_void_p) if vk is not None
-                                      else ctypes.POINTER(ctypes.c_void_p)(),
+                    vj[i].ctypes.data_as(ctypes.c_void_p) if vj is not None else ctypes.POINTER(ctypes.c_void_p)(),
+                    vk[i].ctypes.data_as(ctypes.c_void_p) if vk is not None else ctypes.POINTER(ctypes.c_void_p)(),
             )
 
         mpi_helper.barrier()
@@ -1152,7 +1155,6 @@ class GDF(df.GDF):
 
         return self
 
-
     @property
     def max_memory(self):
         return self.cell.max_memory
@@ -1165,7 +1167,6 @@ class GDF(df.GDF):
     def exxdiv(self):
         # To mimic KSCF in get_coulG
         return None
-
 
     # Cached properties:
 

--- a/vayesta/misc/gto_helper.py
+++ b/vayesta/misc/gto_helper.py
@@ -18,6 +18,7 @@ def loop_neighbor_cells(lattice_vectors=None, dimension=3):
             yield np.asarray(dr)
         yield np.dot(dr, lattice_vectors)
 
+
 def get_atom_distances(mol, point, dimension=None):
     """Get array containing the distances of all atoms to the specified point.
 
@@ -44,6 +45,7 @@ def get_atom_distances(mol, point, dimension=None):
         distances.append(np.amin(dists))
     return np.asarray(distances)
 
+
 def get_atom_shells(mol, point, dimension=None, decimals=5):
     distances = get_atom_distances(mol, point, dimension=dimension)
     drounded = distances.round(decimals)
@@ -51,6 +53,7 @@ def get_atom_shells(mol, point, dimension=None, decimals=5):
     d_uniq, inv = np.unique(drounded[sort], return_inverse=True)
     shells = inv[np.argsort(sort)]
     return shells, distances
+
 
 def make_counterpoise_fragments(mol, fragments, full_basis=True, add_rest_fragment=True, dump_input=True):
     '''Make mol objects for counterpoise calculations.
@@ -70,7 +73,7 @@ def make_counterpoise_fragments(mol, fragments, full_basis=True, add_rest_fragme
     atom_symbols = [mol.atom_symbol(atm_id) for atm_id in range(mol.natm)]
 
     def make_frag_mol(frag):
-        f_mask = numpy.isin(atom_symbols, frag)
+        f_mask = np.isin(atom_symbols, frag)
         if sum(f_mask) == 0:
             raise ValueError("No atoms found for fragment: %r", frag)
         fmol = mol.copy()
@@ -105,18 +108,19 @@ def make_counterpoise_fragments(mol, fragments, full_basis=True, add_rest_fragme
 
     # Add fragment containing all atoms not part of any specified fragments
     if add_rest_fragment:
-        rest_mask = numpy.full((mol.natm,), True)
+        rest_mask = np.full((mol.natm,), True)
         # Set all atoms to False that are part of a fragment
         for frag in fragments:
-            rest_mask = numpy.logical_and(numpy.isin(atom_symbols, frag, invert=True), rest_mask)
-        if numpy.any(rest_mask):
-            rest_frag = numpy.asarray(atom_symbols)[rest_mask]
+            rest_mask = np.logical_and(np.isin(atom_symbols, frag, invert=True), rest_mask)
+        if np.any(rest_mask):
+            rest_frag = np.asarray(atom_symbols)[rest_mask]
             fmol = make_frag_mol(rest_frag)
             fmols.append(fmol)
 
     # TODO: Check that no atom is part of more than one fragments
 
     return fmols
+
 
 if __name__ == '__main__':
 
@@ -125,8 +129,6 @@ if __name__ == '__main__':
     import pyscf.pbc.gto
     import pyscf.pbc.tools
 
-    import vayesta
-    import vayesta.misc
     from vayesta.misc import solids
 
     cell = pyscf.pbc.gto.Cell()

--- a/vayesta/misc/molecules/molecules.py
+++ b/vayesta/misc/molecules/molecules.py
@@ -1,6 +1,7 @@
 import os.path
 import numpy as np
 
+
 def _load_datafile(filename):
     datafile = os.path.join(os.path.dirname(__file__), os.path.join("data", filename))
     data = np.loadtxt(datafile, dtype=[("atoms", object), ("coords", np.float64, (3,))])
@@ -9,6 +10,7 @@ def _load_datafile(filename):
     atom = [[atoms[i], coords[i]] for i in range(len(atoms))]
     return atom
 
+
 def water(atoms=['O', 'H'], origin=(0, 0, 0)):
     origin = np.asarray(origin)
     atom = [[atoms[0], np.asarray([0.0000,  0.0000,  0.1173]) - origin],
@@ -16,12 +18,14 @@ def water(atoms=['O', 'H'], origin=(0, 0, 0)):
             [atoms[1], np.asarray([0.0000, -0.7572, -0.4692]) - origin]]
     return atom
 
+
 def alkane(n, atoms=['C', 'H'], cc_bond=1.54, ch_bond=1.09, scale=1.0, numbering=False):
     """Alkane with idealized tetrahedral (sp3) coordination."""
 
     assert numbering in (False, 'atom', 'unit')
 
     index = 0
+
     def get_symbol(symbol):
         nonlocal index
         if not numbering:
@@ -32,7 +36,7 @@ def alkane(n, atoms=['C', 'H'], cc_bond=1.54, ch_bond=1.09, scale=1.0, numbering
             return out
         return '%s%d' % (symbol, index)
 
-    dk = 1 if (numbering == 'atom') else 0
+    #dk = 1 if (numbering == 'atom') else 0
 
     phi = np.arccos(-1.0/3)
     cph = 1/np.sqrt(3.0)
@@ -66,6 +70,7 @@ def alkane(n, atoms=['C', 'H'], cc_bond=1.54, ch_bond=1.09, scale=1.0, numbering
 
     return atom
 
+
 def alkene(ncarbon, cc_bond=1.33, ch_bond=1.09):
     """Alkene with idealized trigonal planar (sp2) coordination."""
 
@@ -90,6 +95,7 @@ def alkene(ncarbon, cc_bond=1.33, ch_bond=1.09):
 
     return atom
 
+
 def arene(n, atoms=['C', 'H'], cc_bond=1.39, ch_bond=1.09, unit=1.0):
     """Bond length for benzene."""
     r1 = unit*cc_bond/(2*np.sin(np.pi/n))
@@ -102,13 +108,15 @@ def arene(n, atoms=['C', 'H'], cc_bond=1.39, ch_bond=1.09, unit=1.0):
         atom.append((atoms[atomidx+1], (r2*np.cos(phi), r2*np.sin(phi), 0.0)))
     return atom
 
+
 def no2():
     atom = [
-	('N', (0.0000,  0.0000, 0.0000)),
-	('O', (0.0000,  1.0989, 0.4653)),
-	('O', (0.0000, -1.0989, 0.4653)),
-	]
+        ('N', (0.0000,  0.0000, 0.0000)),
+        ('O', (0.0000,  1.0989, 0.4653)),
+        ('O', (0.0000, -1.0989, 0.4653)),
+    ]
     return atom
+
 
 def ethanol(oh_bond=None):
     atom = _load_datafile('ethanol.dat')
@@ -120,6 +128,7 @@ def ethanol(oh_bond=None):
         pos_h = pos_o + oh_bond*voh
         atom[3][1] = pos_h
     return atom
+
 
 def ketene(cc_bond=None):
     atom = _load_datafile('ketene.dat')
@@ -134,6 +143,7 @@ def ketene(cc_bond=None):
         atom[2][1] = new_o
     return atom
 
+
 def ring(atom, natom, bond_length, z=0.0):
     r = bond_length/(2*np.sin(np.pi/natom))
     atoms = []
@@ -141,8 +151,9 @@ def ring(atom, natom, bond_length, z=0.0):
         atom = [atom]
     for i in range(natom):
         theta = i * (2*np.pi/natom)
-        atoms.append([atom[i%len(atom)], np.asarray([r*np.cos(theta), r*np.sin(theta), z])])
+        atoms.append([atom[i % len(atom)], np.asarray([r*np.cos(theta), r*np.sin(theta), z])])
     return atoms
+
 
 # --- From datafiles:
 
@@ -150,30 +161,37 @@ def propyl():
     atom = _load_datafile('propyl.dat')
     return atom
 
+
 def phenyl():
     atom = _load_datafile('phenyl.dat')
     return atom
+
 
 def propanol():
     atom = _load_datafile('propanol.dat')
     return atom
 
+
 def chloroethanol():
     atom = _load_datafile('chloroethanol.dat')
     return atom
+
 
 def neopentane():
     """Structure from B3LYP//aug-cc-pVTZ."""
     atom = _load_datafile('neopentane.dat')
     return atom
 
+
 def boronene():
     atom = _load_datafile('boronene.dat')
     return atom
 
+
 def coronene():
     atom = _load_datafile('coronene.dat')
     return atom
+
 
 def glycine():
     atom = _load_datafile('glycine.dat')

--- a/vayesta/misc/pcdiis.py
+++ b/vayesta/misc/pcdiis.py
@@ -11,7 +11,6 @@ class PCDIIS(pyscf.lib.diis.DIIS):
         self.pref = pref
         super().__init__(*args, **kwargs)
 
-
     def update(self, x):
         y = np.dot(x, self.pref)
         y_new = super().update(y)

--- a/vayesta/misc/solids/solids.py
+++ b/vayesta/misc/solids/solids.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def diamond(atoms=['C', 'C'], a=3.57):
     """Silicon: a=5.431 A"""
     amat = a * np.asarray([
@@ -9,6 +10,7 @@ def diamond(atoms=['C', 'C'], a=3.57):
     coords = a * np.asarray([[0, 0, 0], [1, 1, 1]])/4
     atom = _make_atom(atoms, coords)
     return amat, atom
+
 
 def graphene(atoms=['C', 'C'], a=2.46, c=20.0):
     """
@@ -25,6 +27,7 @@ def graphene(atoms=['C', 'C'], a=2.46, c=20.0):
     atom = _make_atom(atoms, coords)
     return amat, atom
 
+
 def graphite(atoms=['C', 'C', 'C', 'C'], a=2.461, c=6.708):
     """a = 2.461 A , c = 6.708 A"""
     amat = np.asarray([
@@ -39,6 +42,7 @@ def graphite(atoms=['C', 'C', 'C', 'C'], a=2.461, c=6.708):
     coords = np.dot(coords_internal, amat)
     atom = _make_atom(atoms, coords)
     return amat, atom
+
 
 def rocksalt(atoms=['Na', 'Cl'], a=5.6402, primitive=True):
     """
@@ -73,6 +77,7 @@ def rocksalt(atoms=['Na', 'Cl'], a=5.6402, primitive=True):
     atom = _make_atom(4*[atoms[0]]+4*[atoms[1]], coords)
     return amat, atom
 
+
 def perovskite(atoms=['Sr', 'Ti', 'O'], a=3.905):
     if len(atoms) == 3:
         atoms = [atoms[0], atoms[1]] + 3*[atoms[2]]
@@ -83,9 +88,10 @@ def perovskite(atoms=['Sr', 'Ti', 'O'], a=3.905):
                 [0,     1/2,    1/2],
                 [1/2,   0,      1/2],
                 [1/2,   1/2,    0]
-                ])
+    ])
     atom = _make_atom(atoms, coords)
     return amat, atom
+
 
 def perovskite_tetragonal(atoms=['Sr', 'Ti', 'O'], a=5.507, c=7.796, u=0.241):
     """This is the crystallographic ('quadruple') cell, not the primitive ('double') cell.
@@ -134,31 +140,32 @@ def perovskite_tetragonal(atoms=['Sr', 'Ti', 'O'], a=5.507, c=7.796, u=0.241):
     #            ])
     # Order?
     coords_internal = np.asarray([
-                [0      ,   0.5     ,   0.25],  # Sr
-                [0      ,   0       ,   0],     # Ti
-                [0      ,   0       ,   0.25],  # O (4a)
-                [u      ,   0.5+u   ,   0],     # O
-                [0.5+u  ,   u       ,   0.5],   # O
-                [0.5    ,   0       ,   0.75],  # Sr
-                [0.5    ,   0.5     ,   0.5],   # Ti
-                [0.5    ,   0.5     ,   0.75],  # O (4a)
-                [-u     ,   0.5-u   ,   0],     # O
-                [0.5-u  ,   -u      ,   0.5],   # O
-                [0.5    ,   0       ,   0.25],  # Sr
-                [0      ,   0       ,   0.5],   # Ti
-                [0      ,   0       ,   0.75],  # O (4a)
-                [0.5-u  ,   u       ,   0],     # O
-                [-u     ,   0.5+u   ,   0.5],   # O
-                [0      ,   0.5     ,   0.75],  # Sr
-                [0.5    ,   0.5     ,   0],     # Ti
-                [0.5    ,   0.5     ,   0.25],  # O (4a)
-                [0.5+u  ,   -u      ,   0],     # O
-                [u      ,   0.5-u   ,   0.5],   # O
-                ])
+                [0,         0.5,        0.25],  # Sr
+                [0,         0,          0],     # Ti
+                [0,         0,          0.25],  # O (4a)
+                [u,         0.5+u,      0],     # O
+                [0.5+u,     u,          0.5],   # O
+                [0.5,       0,          0.75],  # Sr
+                [0.5,       0.5,        0.5],   # Ti
+                [0.5,       0.5,        0.75],  # O (4a)
+                [-u,        0.5-u,      0],     # O
+                [0.5-u,     -u,         0.5],   # O
+                [0.5,       0,          0.25],  # Sr
+                [0,         0,          0.5],   # Ti
+                [0,         0,          0.75],  # O (4a)
+                [0.5-u,     u,          0],     # O
+                [-u,        0.5+u,      0.5],   # O
+                [0,         0.5,        0.75],  # Sr
+                [0.5,       0.5,        0],     # Ti
+                [0.5,       0.5,        0.25],  # O (4a)
+                [0.5+u,     -u,         0],     # O
+                [u,         0.5-u,      0.5],   # O
+    ])
     coords = np.dot(coords_internal, amat)
 
     atom = _make_atom(atoms, coords)
     return amat, atom
+
 
 def _make_atom(atoms, coords):
     atom = []

--- a/vayesta/mpi/interface.py
+++ b/vayesta/mpi/interface.py
@@ -3,7 +3,7 @@ import functools
 from timeit import default_timer
 
 import vayesta
-from vayesta.core.util import *
+from vayesta.core.util import log_time
 from .rma import RMA_Dict
 from .scf import scf_with_mpi
 
@@ -91,12 +91,15 @@ class MPI_Interface:
             # No MPI:
             if self.disabled:
                 return func
+
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 res = func(*args, **kwargs)
                 res = self.world.reduce(res, **mpi_kwargs)
                 return res
+
             return wrapper
+
         return decorator
 
     def with_allreduce(self, **mpi_kwargs):
@@ -104,12 +107,15 @@ class MPI_Interface:
             # No MPI:
             if self.disabled:
                 return func
+
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 res = func(*args, **kwargs)
                 res = self.world.allreduce(res, **mpi_kwargs)
                 return res
+
             return wrapper
+
         return decorator
 
     def only_master(self):
@@ -117,12 +123,15 @@ class MPI_Interface:
             # No MPI:
             if self.disabled:
                 return func
+
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
-                if not mpi.is_master:
+                if not self.is_master:
                     return None
                 return func(*args, **kwargs)
+
             return wrapper
+
         return decorator
 
     # --- Function wrapper at fragment level
@@ -135,6 +144,7 @@ class MPI_Interface:
                 return func
             # With MPI:
             tag2 = self.get_new_tag() if tag is None else tag
+
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 if callable(source):
@@ -156,7 +166,9 @@ class MPI_Interface:
                 else:
                     self.log.debugv("MPI[%d] <do nothing> func=%s source=%d ", self.rank, func.__name__, src)
                 return None
+
             return wrapper
+
         return decorator
 
     def create_rma_dict(self, dictionary):

--- a/vayesta/mpi/rma.py
+++ b/vayesta/mpi/rma.py
@@ -3,9 +3,6 @@ from contextlib import contextmanager
 
 import numpy as np
 
-import vayesta
-from vayesta.core.util import *
-
 log = logging.getLogger(__name__)
 
 
@@ -126,7 +123,10 @@ class RMA_Dict:
         if self.mpi.disabled:
             return self._elements[key]
         element = self._elements[key]
-        log.debugv("RMA: origin= %d, target= %d, key= %r, shape= %r, dtype= %r", self.mpi.rank, element.location, key, element.shape, element.dtype)
+        log.debugv(
+                "RMA: origin= %d, target= %d, key= %r, shape= %r, dtype= %r",
+                self.mpi.rank, element.location, key, element.shape, element.dtype,
+        )
         return element.get()
 
     def __setitem__(self, key, value):
@@ -168,7 +168,8 @@ class RMA_Dict:
 
     def _get_metadata(self):
         """Get shapes and datatypes of local data."""
-        #return {key: (getattr(val, 'shape', None), getattr(val, 'dtype', type(None))) for key, val in self.local_data.items()}
+        #return {key: (getattr(val, 'shape', None), getattr(val, 'dtype', type(None)))
+        #        for key, val in self.local_data.items()}
         mdata = {}
         for key, val in self.local_data.items():
             shape = getattr(val, 'shape', None)

--- a/vayesta/mpi/scf.py
+++ b/vayesta/mpi/scf.py
@@ -1,9 +1,7 @@
 import functools
 import logging
 
-import vayesta
-import vayesta.core
-from vayesta.core.util import *
+from vayesta.core.util import log_time
 
 
 def scf_with_mpi(mpi, mf, mpi_rank=0, log=None):

--- a/vayesta/rpa/rpa.py
+++ b/vayesta/rpa/rpa.py
@@ -11,7 +11,7 @@ import numpy as np
 import scipy.linalg
 
 from pyscf import ao2mo
-from vayesta.core.util import *
+from vayesta.core.util import time_string
 
 
 class RPA:
@@ -40,7 +40,7 @@ class RPA:
     def e_corr(self):
         try:
             return self.e_corr_ss + self.e_corr_sf
-        except AttributeError as e:
+        except AttributeError:
             self.log.critical("Can only access rpa.e_corr after running rpa.kernel.")
 
     @property

--- a/vayesta/rpa/ssrpa.py
+++ b/vayesta/rpa/ssrpa.py
@@ -9,7 +9,7 @@ import scipy.linalg
 import scipy
 
 import pyscf.ao2mo
-from vayesta.core.util import *
+from vayesta.core.util import dot, einsum, time_string
 
 
 class ssRPA:
@@ -61,7 +61,7 @@ class ssRPA:
     def e_corr(self):
         try:
             return self.e_corr_ss
-        except AttributeError as e:
+        except AttributeError:
             self.log.critical("Can only access rpa.e_corr after running rpa.kernel.")
 
     @property
@@ -154,8 +154,10 @@ class ssRPA:
         elif version == 2:
             # Linear approximation of all quantities in adiabatic connection.
             e = 0.5 * (np.dot(full_mom0, ApB) - (0.5 * (ApB + AmB) - A_xc)).trace()
-            e -= (einsum("pq,qp->", A_xc + B_xc, full_mom0 + np.eye(self.ov)) +
-                  einsum("pq,qp->", A_xc - B_xc, np.linalg.inv(full_mom0) + np.eye(self.ov))) / 8
+            e -= (
+                + einsum("pq,qp->", A_xc + B_xc, full_mom0 + np.eye(self.ov))
+                + einsum("pq,qp->", A_xc - B_xc, np.linalg.inv(full_mom0) + np.eye(self.ov))
+            ) / 8
         elif version == 3:
             # Linear approximation in AC and approx of inverse.
             e = 0.5 * (np.dot(full_mom0, ApB - B_xc / 2) - (0.5 * (ApB + AmB) - B_xc / 2)).trace()

--- a/vayesta/rpa/ssurpa.py
+++ b/vayesta/rpa/ssurpa.py
@@ -3,9 +3,7 @@ import numpy as np
 import scipy.linalg
 
 from timeit import default_timer as timer
-from vayesta.core.util import *
-
-import pyscf.ao2mo
+from vayesta.core.util import dot, time_string
 
 
 class ssURPA(ssRPA):

--- a/vayesta/solver/cisd.py
+++ b/vayesta/solver/cisd.py
@@ -1,9 +1,9 @@
+import copy
 import pyscf
 import pyscf.ci
-from vayesta.core.util import *
+from vayesta.core.util import einsum, log_time, deprecated
 from vayesta.core.types import WaveFunction
 from .ccsd import CCSD_Solver
-from .solver import ClusterSolver
 
 
 class CISD_Solver(CCSD_Solver):
@@ -19,7 +19,8 @@ class CISD_Solver(CCSD_Solver):
     def kernel(self, eris=None):
 
         # Integral transformation
-        if eris is None: eris = self.get_eris()
+        if eris is None:
+            eris = self.get_eris()
 
         # Add additional potential
         if self.v_ext is not None:
@@ -80,13 +81,14 @@ class CISD_Solver(CCSD_Solver):
         return None
 
     def get_init_guess(self):
-        return {'c0' : self.c0, 'c1' : self.c1 , 'c2' : self.c2}
+        return {'c0': self.c0, 'c1': self.c1, 'c2': self.c2}
 
     def make_rdm1(self, *args, **kwargs):
         raise NotImplementedError()
 
     def make_rdm2(self, *args, **kwargs):
         raise NotImplementedError()
+
 
 class UCISD_Solver(CISD_Solver):
 

--- a/vayesta/solver/dump.py
+++ b/vayesta/solver/dump.py
@@ -16,7 +16,8 @@ class DumpSolver(ClusterSolver):
             h5file = self.opts.filename
         if eris is None:
             eris = self.get_eris()
-        with h5file as f:
+        #with h5file as f:
+        with h5file:
             grp = h5file.create_group('fragment_%d' % self.fragment.id)
             # Attributes
             grp.attrs['id'] = self.fragment.id

--- a/vayesta/solver/ebfci.py
+++ b/vayesta/solver/ebfci.py
@@ -2,7 +2,7 @@ import dataclasses
 
 import numpy as np
 
-from vayesta.core.util import *
+from vayesta.core.util import timer, time_string, energy_string
 from vayesta.solver.fci import FCI_Solver, UFCI_Solver
 from vayesta.solver.solver import EBClusterSolver
 from .eb_fci import ebfci_slow, uebfci_slow
@@ -122,9 +122,16 @@ class UEBFCI_Solver(EBFCI_Solver, UFCI_Solver):
             couplings = tuple([x+y for x, y in zip(couplings, coupling_shift)])
 
         t0 = timer()
-        self.e_fci, self.civec = uebfci_slow.kernel(heff, eris, couplings,
-                                                   np.diag(self.fragment.bos_freqs), self.ncas, self.nelec, self.nbos,
-                                                   self.opts.max_boson_occ)
+        self.e_fci, self.civec = uebfci_slow.kernel(
+                heff,
+                eris,
+                couplings,
+                np.diag(self.fragment.bos_freqs),
+                self.ncas,
+                self.nelec,
+                self.nbos,
+                self.opts.max_boson_occ,
+        )
         # Getting convergence detail out pretty complicated, and nonconvergence rare- just assume for now.
         self.log.timing("Time for EBFCI: %s", time_string(timer() - t0))
         self.log.debugv("E(CAS)= %s", energy_string(self.e_fci))

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -10,7 +10,7 @@ import pyscf.mcscf
 import pyscf.fci
 import pyscf.fci.addons
 
-from vayesta.core.util import *
+from vayesta.core.util import einsum, deprecated, timer, time_string, energy_string
 from vayesta.core.types import Orbitals
 from vayesta.core.types import FCI_WaveFunction
 from .solver import ClusterSolver
@@ -36,10 +36,14 @@ class FCI_Solver(ClusterSolver):
         solver = solver_cls(self.mol)
         self.log.debugv("type(solver)= %r", type(solver))
         # Set options
-        if self.opts.threads is not None: solver.threads = self.opts.threads
-        if self.opts.conv_tol is not None: solver.conv_tol = self.opts.conv_tol
-        if self.opts.lindep is not None: solver.lindep = self.opts.lindep
-        if self.opts.max_cycle is not None: solver.max_cycle = self.opts.max_cycle
+        if self.opts.threads is not None:
+            solver.threads = self.opts.threads
+        if self.opts.conv_tol is not None:
+            solver.conv_tol = self.opts.conv_tol
+        if self.opts.lindep is not None:
+            solver.lindep = self.opts.lindep
+        if self.opts.max_cycle is not None:
+            solver.max_cycle = self.opts.max_cycle
         if self.opts.fix_spin not in (None, False):
             spin = self.opts.fix_spin
             self.log.debugv("Fixing spin of FCI solver to S^2= %f", spin)
@@ -73,7 +77,7 @@ class FCI_Solver(ClusterSolver):
         return 2*self.cluster.nocc_active
 
     def get_init_guess(self):
-        return {'ci0' : self.civec}
+        return {'ci0': self.civec}
 
     @deprecated()
     def get_t1(self):
@@ -104,7 +108,8 @@ class FCI_Solver(ClusterSolver):
     def kernel(self, ci0=None, eris=None):
         """Run FCI kernel."""
 
-        if eris is None: eris = self.get_eris()
+        if eris is None:
+            eris = self.get_eris()
         heff = self.get_heff(eris)
 
         t0 = timer()
@@ -164,6 +169,7 @@ class FCI_Solver(ClusterSolver):
         wf = FCI_WaveFunction(mo, ci)
         self.wf = wf
         self.converged = True
+
 
 class UFCI_Solver(FCI_Solver):
     """FCI with UHF orbitals."""
@@ -254,11 +260,13 @@ class UFCI_Solver(FCI_Solver):
         return c0, (c1a, c1b), (c2aa, c2ab, c2bb)
 
     def make_rdm1(self, civec=None):
-        if civec is None: civec = self.civec
+        if civec is None:
+            civec = self.civec
         self.dm1 = self.solver.make_rdm1s(civec, self.ncas, self.nelec)
         return self.dm1
 
     def make_rdm12(self, civec=None):
-        if civec is None: civec = self.civec
+        if civec is None:
+            civec = self.civec
         self.dm1, self.dm2 = self.solver.make_rdm12s(civec, self.ncas, self.nelec)
         return self.dm1, self.dm2

--- a/vayesta/solver/mp2.py
+++ b/vayesta/solver/mp2.py
@@ -2,15 +2,16 @@ import numpy as np
 
 from .solver import ClusterSolver
 
-from vayesta.core.util import *
+from vayesta.core.util import einsum, deprecated, log_time, brange
 from vayesta.core.types import Orbitals
 from vayesta.core.types import MP2_WaveFunction
+
 
 class MP2_Solver(ClusterSolver):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        frozen = self.cluster.get_frozen_indices()
+        self.cluster.get_frozen_indices()
         # --- Results
         self.t2 = None
 

--- a/vayesta/tests/cache.py
+++ b/vayesta/tests/cache.py
@@ -219,6 +219,7 @@ def _make_cell(a, atom, supercell=None, verbose=10, max_memory=int(1e9), **kwarg
         cell = pyscf.pbc.tools.super_cell(cell, supercell)
     return cell
 
+
 def _make_pbc_mf(cell, kpts=None, df=None, xc=None, restricted=None, **kwargs):
     if restricted is None:
         restricted = (cell.spin == 0)
@@ -316,8 +317,11 @@ def register_system_cell(cache, key):
 
     # Rocksalt LiH
     if key == 'lih_k221':
-        cell = _make_cell(*solids.rocksalt(atoms=['Li', 'H']), basis='def2-svp',
-                exp_to_discard=0.1)
+        cell = _make_cell(
+                *solids.rocksalt(atoms=['Li', 'H']),
+                basis='def2-svp',
+                exp_to_discard=0.1,
+        )
         kpts = cell.make_kpts([2,2,1])
         df = pyscf.pbc.df.GDF(cell, kpts)
         df.auxbasis = 'def2-svp-ri'
@@ -325,8 +329,12 @@ def register_system_cell(cache, key):
         cache._cache[key] = {'cell': cell, 'kpts': kpts, 'rhf': mf, 'uhf': None}
         return
     if key == 'lih_g221':
-        cell = _make_cell(*solids.rocksalt(atoms=['Li', 'H']), basis='def2-svp',
-                exp_to_discard=0.1, supercell=[2,2,1])
+        cell = _make_cell(
+                *solids.rocksalt(atoms=['Li', 'H']),
+                basis='def2-svp',
+                exp_to_discard=0.1,
+                supercell=[2,2,1],
+        )
         df = pyscf.pbc.df.GDF(cell)
         df.auxbasis = 'def2-svp-ri'
         mf = _make_pbc_mf(cell, df=df)
@@ -358,7 +366,14 @@ def register_system_cell(cache, key):
         cache._cache[key] = {'cell': cell, 'kpts': kpts, 'rhf': mf, 'uhf': None}
         return
     if key == 'graphene_g221':
-        cell = _make_cell(*solids.graphene(c=30.0), dimension=2, basis='def2-svp', exp_to_discard=0.1, supercell=[2,2,1], precision=1e-12)
+        cell = _make_cell(
+                *solids.graphene(c=30.0),
+                dimension=2,
+                basis='def2-svp',
+                exp_to_discard=0.1,
+                supercell=[2,2,1],
+                precision=1e-12,
+        )
         df = pyscf.pbc.df.GDF(cell)
         df.auxbasis = 'def2-svp-ri'
         mf = _make_pbc_mf(cell, df=df)
@@ -383,7 +398,6 @@ def register_system_cell(cache, key):
         mf = _make_pbc_mf(cell, df=df)
         cache._cache[key] = {'cell': cell, 'kpts': None, 'rhf': None, 'uhf': mf}
         return
-
 
     cell = pyscf.pbc.gto.Cell()
     kpts = None


### PR DESCRIPTION
Lints all files except for tests and examples to satisfy the `flake8`, to nearly full PEP8 compliance - I ignored a few cases that I thought were restrictive or counter-productive, see the `.flake8`. Obviously satisfying the linter means changing people's codestyle, and some of this comes down to personal preference, particularly in the case of multiple line statements - if anyone sees some style pattern in your code that you don't like then let me know and I can change things.

Please don't merge this until after #17 is merged.