### PR TITLE
Revert "Disables IAO fragmentation for DMET"

### DIFF
--- a/vayesta/dmet/dmet.py
+++ b/vayesta/dmet/dmet.py
@@ -290,7 +290,5 @@ class DMET(Embedding):
             dm2 = self.make_rdm2()
         return super().get_corrfunc(kind, dm1=dm1, dm2=dm2, **kwargs)
 
-    def iao_fragmentation(self, *args, **kwargs):
-        raise ValueError("IAO fragmentation is not available for DMET")
 
 RDMET = DMET

--- a/vayesta/tests/dmet/test_dmet_molecule.py
+++ b/vayesta/tests/dmet/test_dmet_molecule.py
@@ -33,7 +33,7 @@ class MoleculeDMETTest(TestCase):
         """
         emb = dmet.DMET(testsystems.h6_sto6g.rhf(), solver='FCI', charge_consistent=True,
                 bath_options=dict(bathtype='dmet'), conv_tol=self.CONV_TOL)
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -49,7 +49,7 @@ class MoleculeDMETTest(TestCase):
         """
         emb = dmet.DMET(testsystems.h6_sto6g.rhf(), solver='FCI', charge_consistent=False,
                 bath_options=dict(bathtype='dmet'), conv_tol=self.CONV_TOL)
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -65,7 +65,7 @@ class MoleculeDMETTest(TestCase):
         """
         emb = dmet.DMET(testsystems.h6_sto6g.rhf(), solver='CCSD', charge_consistent=False,
                 bath_options=dict(bathtype='dmet'), conv_tol=self.CONV_TOL)
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -82,7 +82,7 @@ class MoleculeDMETTest(TestCase):
         """
         emb = dmet.DMET(testsystems.h6_sto6g.rhf(), solver='FCI', charge_consistent=False,
                 bath_options=dict(bathtype='full'), conv_tol=self.CONV_TOL)
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])

--- a/vayesta/tests/edmet/test_dfedmet_molecule.py
+++ b/vayesta/tests/edmet/test_dfedmet_molecule.py
@@ -29,7 +29,7 @@ class MolecularDFEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -49,7 +49,7 @@ class MolecularDFEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -64,7 +64,7 @@ class MolecularDFEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with uemb.sao_fragmentation() as f:
+        with uemb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -85,7 +85,7 @@ class MolecularDFEDMETTest(TestCase):
                 make_dd_moments=False,
                 bosonic_interaction="direct",
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_all_atomic_fragments()
         emb.kernel()
 
@@ -101,7 +101,7 @@ class MolecularDFEDMETTest(TestCase):
                 make_dd_moments=False,
                 bosonic_interaction="direct",
         )
-        with uemb.sao_fragmentation() as f:
+        with uemb.iao_fragmentation() as f:
             f.add_all_atomic_fragments()
         uemb.kernel()
 

--- a/vayesta/tests/edmet/test_edmet_molecule.py
+++ b/vayesta/tests/edmet/test_edmet_molecule.py
@@ -30,7 +30,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -45,7 +45,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with uemb.sao_fragmentation() as f:
+        with uemb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -63,7 +63,7 @@ class MolecularEDMETTest(TestCase):
                 solver_options={"max_boson_occ":2},
                 conv_tol=self.CONV_TOL,
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -78,7 +78,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with uemb.sao_fragmentation() as f:
+        with uemb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -100,7 +100,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -119,7 +119,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with uemb.sao_fragmentation() as f:
+        with uemb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])
             f.add_atomic_fragment([4, 5])
@@ -137,7 +137,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with emb.sao_fragmentation() as f:
+        with emb.iao_fragmentation() as f:
             f.add_all_atomic_fragments()
         emb.kernel()
 
@@ -153,7 +153,7 @@ class MolecularEDMETTest(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
-        with uemb.sao_fragmentation() as f:
+        with uemb.iao_fragmentation() as f:
             f.add_all_atomic_fragments()
         uemb.kernel()
 


### PR DESCRIPTION
This reverts commit 1db7d1f4ee14b99844fb0a6380acf75a6fbabd52.
While I don't think the IAO fragmentation is a good idea for production DMET calculations, it's useful to be able to use for testing and similar, and given the delta RPA correction in EDMET it might not be unreasonable to have as an option there.
As such this seems a bit heavy-handed, while also breaking all these tests (as all computed values will change) and making them take an age to run.
