### PR TITLE
Package installation fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
             "Operating System :: MacOS :: MacOS X",
             "Operating System :: POSIX :: Linux",
     ],
-    packages=find_packages(exclude=["*tests*", "*examples*"]),
+    packages=find_packages(exclude=["*examples*"]),
     include_package_data=True,
     install_requires=[
             "wheel",


### PR DESCRIPTION
Should fix #29:

- Changes `setup.py` to include tests in package directory
- Adds missing `__init__.py` to `solver/eb_fci`