### PR TITLE
CAS update+RIRPA floating point overflows

### DIFF
--- a/vayesta/rpa/rirpa/RIRPA.py
+++ b/vayesta/rpa/rirpa/RIRPA.py
@@ -217,12 +217,18 @@ class ssRIRPA:
         peta_norm = np.linalg.norm(einsum("p,qp->pq", self.D, mom0) + dot(ri_apb[0].T, l1[1].T))
 
         # Now to estimate resulting error estimate in eta0.
-        poly = np.polynomial.Polynomial([e_norm / p_norm, -2 * peta_norm / p_norm, 1])
-        roots = poly.roots()
-        self.log.info("Proportional error in eta0 relation=%6.4e", e_norm / np.linalg.norm(amb_exact))
-        self.log.info("Resulting error lower bound: %6.4e", roots.min())
-
-        return roots.min()
+        try:
+            poly = np.polynomial.Polynomial([e_norm/p_norm, -2 * peta_norm / p_norm, 1])
+            roots = poly.roots()
+        except np.linalg.LinAlgError:
+            self.log.warning("Could not obtain eta0 error lower bound; this is usually due to vanishing norms: %e, "
+                             "%e, %e.",
+                             e_norm, p_norm, peta_norm)
+            return 0.0
+        else:
+            self.log.info("Proportional error in eta0 relation=%6.4e", e_norm / np.linalg.norm(amb_exact))
+            self.log.info("Resulting error lower bound: %6.4e", roots.min())
+            return roots.min()
 
     def kernel_trMPrt(self, npoints=48, ainit=10):
         """Evaluate Tr((MP)^(1/2))."""

--- a/vayesta/tests/ewf/test_molecules.py
+++ b/vayesta/tests/ewf/test_molecules.py
@@ -391,7 +391,7 @@ class UMoleculeEWFTests(unittest.TestCase):
                 },
         )
         with rewf.cas_fragmentation() as f:
-            f.add_cas_fragment(2, 4)
+            f.add_cas_fragment(4, 2)
         rewf.kernel()
 
         uewf = ewf.UEWF(
@@ -403,7 +403,7 @@ class UMoleculeEWFTests(unittest.TestCase):
                 },
         )
         with uewf.cas_fragmentation() as f:
-            f.add_cas_fragment(2, 4)
+            f.add_cas_fragment(4, 2)
         uewf.kernel()
 
         self.assertAlmostEqual(rewf.e_corr, uewf.e_corr, self.PLACES_ENERGY)


### PR DESCRIPTION
Quick update to CAS fragmentation functionality, with a minor tweak to RIRPA as well.
This adds reporting of the occupied and virtual energy gaps when adding a fragment, and covers a few more edge cases related to these quantities to ensure degenerate orbitals aren't being split in the cas.

While doing this, I updated us to be consistent with `pyscf`'s CAS specification, so we have
```
with emb.cas_fragmentation() as f:
     f.add_cas_fragment(ncas, nelec)
```
rather than swapping the inputs.

Finally, I had another look at occasional floating-point overflow errors in the RIRPA, which @maxnus originally flagged and I thought were mislabelled underflow errors.
Making changes to ensure suppression of those errors didn't solve the problem, so I had a closer look and managed to identify that very occasionally `np.polynomial.laguerre.laggauss` is failing to correctly generate its expected frequency points.

This can result in a negative frequency point, which should be impossible, and leads to the exponential blowing up to the observed overflow errors.
Given generation requires the roots of the corresponding Laguerre polynomial numerical instability makes some sense, but I can't observe it with any consistency, and it seems for a given interpreter behaviour is deterministically stable or unstable.
As such I've added a check when the quadrature grid is generated for negative frequency points, and in their presence the quadrature is regenerated via the alternative implementation `scipy.special.roots_laguerre`.
With any luck the chances of the two separate (and non-identical) implementations both running into the same problem is vanishing and should catch most cases.

If neither returns a purely positive set of points I've regretfully added a `RuntimeError`, just because even though I think these are low-weighted extremal points that seem not to change our results, it is hypothetically undefined behaviour which I, to be honest, don't totally understand.
If we keep running into issues with this I can add a fall-back to a Curtis-Clenshaw quadrature, which should avoid all these problems at the cost of requiring more quadrature points.
