### PR TITLE
Fix bug in UHF 2dm cumulant 

### DIFF
--- a/vayesta/core/ao2mo/helper.py
+++ b/vayesta/core/ao2mo/helper.py
@@ -433,7 +433,9 @@ def contract_dm2intermeds_eris_uhf(dm2, eris, destroy_dm2=True):
     e2 += _contract_4d(_get_block('ovOV'), eris.ovOV) * 4
     e2 += _contract_4d(_get_block('ovVV'), get_ovVV(eris, block='ovVV')) * 4
     e2 += _contract_4d(_get_block('OVvv'), get_ovVV(eris, block='OVvv')) * 4
-    e2 += _contract_4d(_get_block('vvVV'), get_vvVV(eris)) * 2
+    gamma_vvVV = _get_block('vvVV')
+    if not 0 in gamma_vvVV.shape:
+        e2 += _contract_4d(gamma_vvVV, get_vvVV(eris)) * 2
     return e2
 
 

--- a/vayesta/core/ao2mo/helper.py
+++ b/vayesta/core/ao2mo/helper.py
@@ -224,7 +224,8 @@ def get_vvVV(eris, block='vvVV'):
         if gvvvv.ndim == 4:
             return gvvvv[:]
         else:
-            xVV = pyscf.lib.unpack_tril(gvvvv[:], axis=0).reshape(nvirL**2, -1)
+            nvv = (-1 if gvvvv.size else 0)
+            xVV = pyscf.lib.unpack_tril(gvvvv[:], axis=0).reshape(nvirL**2, nvv)
             return pyscf.lib.unpack_tril(xVV[:], axis=1).reshape(nvirL,nvirL,nvirR,nvirR)
     raise NotImplementedError
 
@@ -433,9 +434,7 @@ def contract_dm2intermeds_eris_uhf(dm2, eris, destroy_dm2=True):
     e2 += _contract_4d(_get_block('ovOV'), eris.ovOV) * 4
     e2 += _contract_4d(_get_block('ovVV'), get_ovVV(eris, block='ovVV')) * 4
     e2 += _contract_4d(_get_block('OVvv'), get_ovVV(eris, block='OVvv')) * 4
-    gamma_vvVV = _get_block('vvVV')
-    if not 0 in gamma_vvVV.shape:
-        e2 += _contract_4d(gamma_vvVV, get_vvVV(eris)) * 2
+    e2 += _contract_4d(_get_block('vvVV'), get_vvVV(eris)) * 2
     return e2
 
 

--- a/vayesta/dmet/__init__.py
+++ b/vayesta/dmet/__init__.py
@@ -5,6 +5,7 @@ email:  cjcargillscott@gmail.com
 
 import pyscf
 import pyscf.scf
+import logging
 
 try:
     import cvxpy
@@ -14,8 +15,13 @@ except ModuleNotFoundError as e:
 from .dmet import RDMET
 from .udmet import UDMET
 
+log = logging.getLogger(__name__)
+
 def DMET(mf, *args, **kwargs):
     """Determine restricted or unrestricted by inspection of mean-field object"""
     if isinstance(mf, pyscf.scf.uhf.UHF):
         return UDMET(mf, *args, **kwargs)
+    elif isinstance(mf, pyscf.scf.rohf.ROHF):
+        log.warning("Converting ROHF reference to UHF")
+        return UDMET(mf.to_uhf(), *args, **kwargs)
     return RDMET(mf, *args, **kwargs)

--- a/vayesta/edmet/__init__.py
+++ b/vayesta/edmet/__init__.py
@@ -5,12 +5,18 @@ email:  cjcargillscott@gmail.com
 
 import pyscf
 import pyscf.scf
+import logging
 
 from .edmet import REDMET
 from .uedmet import UEDMET
+
+log = logging.getLogger(__name__)
 
 def EDMET(mf, *args, **kwargs):
     """Determine restricted or unrestricted by inspection of mean-field object"""
     if isinstance(mf, pyscf.scf.uhf.UHF):
         return UEDMET(mf, *args, **kwargs)
+    elif isinstance(mf, pyscf.scf.rohf.ROHF):
+        log.warning("Converting ROHF reference to UHF")
+        return UEMET(mf.to_uhf(), *args, **kwargs)
     return REDMET(mf, *args, **kwargs)

--- a/vayesta/ewf/__init__.py
+++ b/vayesta/ewf/__init__.py
@@ -5,13 +5,19 @@ email:  max.nusspickel@gmail.com
 
 import pyscf
 import pyscf.scf
+import logging 
 
 #from .ewf import EWF as REWF
 from .ewf import REWF
 from .uewf import UEWF
 
+log = logging.getLogger(__name__)
+
 def EWF(mf, *args, **kwargs):
     """Determine restricted or unrestricted by inspection of mean-field object"""
     if isinstance(mf, pyscf.scf.uhf.UHF):
         return UEWF(mf, *args, **kwargs)
+    elif isinstance(mf, pyscf.scf.rohf.ROHF):
+        log.warning("Converting ROHF reference to UHF")
+        return UEWF(mf.to_uhf(), *args, **kwargs)
     return REWF(mf, *args, **kwargs)

--- a/vayesta/rpa/rirpa/RIRPA.py
+++ b/vayesta/rpa/rirpa/RIRPA.py
@@ -217,12 +217,18 @@ class ssRIRPA:
         peta_norm = np.linalg.norm(einsum("p,qp->pq", self.D, mom0) + dot(ri_apb[0].T, l1[1].T))
 
         # Now to estimate resulting error estimate in eta0.
-        poly = np.polynomial.Polynomial([e_norm / p_norm, -2 * peta_norm / p_norm, 1])
-        roots = poly.roots()
-        self.log.info("Proportional error in eta0 relation=%6.4e", e_norm / np.linalg.norm(amb_exact))
-        self.log.info("Resulting error lower bound: %6.4e", roots.min())
-
-        return roots.min()
+        try:
+            poly = np.polynomial.Polynomial([e_norm/p_norm, -2 * peta_norm / p_norm, 1])
+            roots = poly.roots()
+        except np.linalg.LinAlgError:
+            self.log.warning("Could not obtain eta0 error lower bound; this is usually due to vanishing norms: %e, "
+                             "%e, %e.",
+                             e_norm, p_norm, peta_norm)
+            return 0.0
+        else:
+            self.log.info("Proportional error in eta0 relation=%6.4e", e_norm / np.linalg.norm(amb_exact))
+            self.log.info("Resulting error lower bound: %6.4e", roots.min())
+            return roots.min()
 
     def kernel_trMPrt(self, npoints=48, ainit=10):
         """Evaluate Tr((MP)^(1/2))."""

--- a/vayesta/tests/common.py
+++ b/vayesta/tests/common.py
@@ -26,7 +26,15 @@ class TestCase(unittest.TestCase):
                 self.assertAllclose(actual[i], desired[i], rtol=rtol, atol=atol, **kwargs)
             return
         # Compare single pair of arrays:
-        np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol, **kwargs)
+        try:
+            np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol, **kwargs)
+        except AssertionError as e:
+            # Add higher precision output:
+            message = e.args[0]
+            args = e.args[1:]
+            message += '\nHigh precision:\n x: %r\n y: %r' % (actual, desired)
+            e.args = (message, *args)
+            raise
 
 
 if __name__ == '__main__':

--- a/vayesta/tests/core/ao2mo/test_postscf_ao2mo.py
+++ b/vayesta/tests/core/ao2mo/test_postscf_ao2mo.py
@@ -165,10 +165,7 @@ class PostSCF_KAO2GMO_Tests(TestCase):
                     if expected is None:
                         continue
                     val = getattr(eris, attr)
-
-                    if hasattr(expected, 'shape'):
-                        self.assertEqual(val.shape, expected.shape)
-                    self.assertIsNone(np.testing.assert_almost_equal(val, expected))
+                    self.assertAllclose(val, expected)
 
 
 if __name__ == '__main__':

--- a/vayesta/tests/ewf/test_h2_pbc.py
+++ b/vayesta/tests/ewf/test_h2_pbc.py
@@ -316,9 +316,9 @@ class Test_MP2_2D(Test_MP2):
         cls.ref_values = {
                 ('e_corr', -1) : cls.cc.e_corr/nk,
                 ('e_tot', -1) : cls.cc.e_tot/nk,
-                ('e_corr', 1e-3) : -0.013768225879056828,
-                ('e_tot', 1e-3) : -1.3539350680412634,
+                ('e_corr', 1e-3) : -0.013768516654027911,
                 }
+        cls.ref_values[('e_tot', 1e-3)] = cls.mf.e_tot + cls.ref_values[('e_corr', 1e-3)]
 
 @pytest.mark.slow
 class Test_CCSD_2D(Test_CCSD):
@@ -331,9 +331,9 @@ class Test_CCSD_2D(Test_CCSD):
         cls.ref_values = {
                 ('e_corr', -1) : cls.cc.e_corr/nk,
                 ('e_tot', -1) : cls.cc.e_tot/nk,
-                ('e_corr', 1e-3) : -0.01982151735237517,
-                ('e_tot', 1e-3) : -1.3599883595145819,
+                ('e_corr', 1e-3) : -0.019821885830904003,
                 }
+        cls.ref_values[('e_tot', 1e-3)] = cls.mf.e_tot + cls.ref_values[('e_corr', 1e-3)]
 
 if __name__ == '__main__':
     print('Running %s' % __file__)

--- a/vayesta/tests/ewf/test_molecules.py
+++ b/vayesta/tests/ewf/test_molecules.py
@@ -391,7 +391,7 @@ class UMoleculeEWFTests(unittest.TestCase):
                 },
         )
         with rewf.cas_fragmentation() as f:
-            f.add_cas_fragment(2, 4)
+            f.add_cas_fragment(4, 2)
         rewf.kernel()
 
         uewf = ewf.UEWF(
@@ -403,7 +403,7 @@ class UMoleculeEWFTests(unittest.TestCase):
                 },
         )
         with uewf.cas_fragmentation() as f:
-            f.add_cas_fragment(2, 4)
+            f.add_cas_fragment(4, 2)
         uewf.kernel()
 
         self.assertAlmostEqual(rewf.e_corr, uewf.e_corr, self.PLACES_ENERGY)

--- a/vayesta/tests/misc/test_molstructs.py
+++ b/vayesta/tests/misc/test_molstructs.py
@@ -12,7 +12,7 @@ from vayesta.tests.common import TestCase
 
 @pytest.mark.fast
 class MolstructsTests(TestCase):
-    PLACES_ENERGY = 12
+    PLACES_ENERGY = 7
 
     def _test_nuclear_energy(self, mol, known_values):
         """Test the nuclear energy.

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -130,7 +130,7 @@ class TestSolid:
     """Solid test system."""
 
     def __init__(self, a, atom, basis, kmesh=None, auxbasis=None, supercell=None, exxdiv='ewald', df='gdf',
-                 precision=1e-9, verbose=PYSCF_VERBOSITY, **kwargs):
+                 precision=1e-10, verbose=PYSCF_VERBOSITY, **kwargs):
         super().__init__()
         mol = pyscf.pbc.gto.Cell()
         mol.a = a


### PR DESCRIPTION
Contraction of vvVV block with eris when nvira xor nvirb is zero, fails.
Added check to skip that contribution when necessary. 