### PR TITLE
BNO finite bath correction

### DIFF
--- a/vayesta/core/bath/bath.py
+++ b/vayesta/core/bath/bath.py
@@ -18,6 +18,10 @@ class Bath:
         return (np.ndim(self.mf.mo_coeff[0]) == 2)
 
     @property
+    def spinsym(self):
+        return self.fragment.spinsym
+
+    @property
     def mf(self):
         return self.fragment.mf
 

--- a/vayesta/core/fragmentation/fragmentation.py
+++ b/vayesta/core/fragmentation/fragmentation.py
@@ -192,11 +192,13 @@ class Fragmentation:
         # Only consider fragments with flags.secfrag_solver set:
         fragments = self.emb.get_fragments(flags=dict(secfrag_solver=lambda x: x is not None))
 
-        def _create_fragment(fx, **kwargs):
+        def _create_fragment(fx, flags=None, **kwargs):
             if fx.sym_parent is not None:
                 raise NotImplementedError("Secondary fragments need to be added before symmetry-derived fragments")
             solver = fx.flags.secfrag_solver
-            fx_copy = fx.copy(solver=solver, flags=dict(is_secfrag=True), **kwargs)
+            flags = (flags or {}).copy()
+            flags['is_secfrag'] = True
+            fx_copy = fx.copy(solver=solver, flags=flags, **kwargs)
             fx_copy.flags.bath_parent_fragment = fx
             self.log.debugv("Adding secondary fragment: %s", fx_copy)
             return fx_copy
@@ -221,9 +223,9 @@ class Fragmentation:
             frag = _create_fragment(fx, name='%s(secondary)' % fx.name, bath_options=bath_opts)
             fragments_sec.append(frag)
             # Double counting
-            frag = _create_fragment(fx, name='%s(secondary-dc)' % fx.name, wf_factor=-1, icmp2_active=False)
+            frag = _create_fragment(fx, name='%s(secondary-dc)' % fx.name, wf_factor=-1, flags=dict(is_envelop=False))
             fragments_sec.append(frag)
-            fx.opts.icmp2_active = False
+            fx.flags.is_envelop = False
         return fragments_sec
 
     # --- For convenience:

--- a/vayesta/core/qemb/fragment.py
+++ b/vayesta/core/qemb/fragment.py
@@ -816,7 +816,6 @@ class Fragment:
         def get_orbitals(occtype):
             factory = getattr(self, '_bath_factory_%s' % occtype[:3])
             btype = self._get_bath_option('bathtype', occtype)
-            e_fbc = 0    # finite bath correction
             if btype == 'dmet':
                 c_bath = None
                 c_frozen = getattr(self._dmet_bath, 'c_env_%s' % occtype[:3])
@@ -831,12 +830,10 @@ class Fragment:
                 truncation = self._get_bath_option('truncation', occtype)
                 bno_threshold = BNO_Threshold(truncation, threshold)
                 c_bath, c_frozen = factory.get_bath(bno_threshold)
-                if self.flags.is_envelop:
-                    e_fbc = factory.get_finite_bath_correction(c_bath, c_frozen)
-            return c_bath, c_frozen, e_fbc
+            return c_bath, c_frozen
 
-        c_bath_occ, c_frozen_occ, e_fbc_occ = get_orbitals('occupied')
-        c_bath_vir, c_frozen_vir, e_fbc_vir = get_orbitals('virtual')
+        c_bath_occ, c_frozen_occ = get_orbitals('occupied')
+        c_bath_vir, c_frozen_vir = get_orbitals('virtual')
         c_active_occ = spinalg.hstack_matrices(self._dmet_bath.c_cluster_occ, c_bath_occ)
         c_active_vir = spinalg.hstack_matrices(self._dmet_bath.c_cluster_vir, c_bath_vir)
         # Canonicalize orbitals
@@ -845,11 +842,6 @@ class Fragment:
         if self._get_bath_option('canonicalize', 'virtual'):
             c_active_vir = self.canonicalize_mo(c_active_vir)[0]
         cluster = Cluster.from_coeffs(c_active_occ, c_active_vir, c_frozen_occ, c_frozen_vir)
-        # Add finite bath correction to cluster object
-        cluster.e_fbc_occ = e_fbc_occ
-        cluster.e_fbc_vir = e_fbc_vir
-        self.log.debug("Finite bath correction:  occ= %s  vir= %s  tot= %s", energy_string(e_fbc_occ),
-                       energy_string(e_fbc_vir), energy_string(e_fbc_occ+e_fbc_vir))
 
         # Check occupations
         def check_occup(mo_coeff, expected):

--- a/vayesta/core/qemb/fragment.py
+++ b/vayesta/core/qemb/fragment.py
@@ -54,20 +54,22 @@ class Options(OptionsBase):
     sym_factor: float = 1.0
 
 
-@dataclasses.dataclass
-class Flags:
-    is_secfrag: bool = False
-    # Secondary fragment parameter
-    secfrag_solver: typing.Optional[str] = None
-    secfrag_bno_threshold: typing.Optional[float] = None
-    secfrag_bno_threshold_factor: float = 0.1
-    bath_parent_fragment: typing.Any = None
-
-
 class Fragment:
 
     Options = Options
-    Flags = Flags
+
+    @dataclasses.dataclass
+    class Flags:
+        # If multiple cluster exist for a given atom, the envelop fragment is
+        # the one with the largest (super) cluster space. This is used, for example,
+        # for the finite-bath and ICMP2 corrections
+        is_envelop: bool = True
+        is_secfrag: bool = False
+        # Secondary fragment parameter
+        secfrag_solver: typing.Optional[str] = None
+        secfrag_bno_threshold: typing.Optional[float] = None
+        secfrag_bno_threshold_factor: float = 0.1
+        bath_parent_fragment: typing.Any = None
 
     @dataclasses.dataclass
     class Results:
@@ -828,7 +830,9 @@ class Fragment:
                 threshold = self._get_bath_option('threshold', occtype)
                 truncation = self._get_bath_option('truncation', occtype)
                 bno_threshold = BNO_Threshold(truncation, threshold)
-                c_bath, c_frozen, e_fbc = factory.get_bath(bno_threshold)
+                c_bath, c_frozen = factory.get_bath(bno_threshold)
+                if self.flags.is_envelop:
+                    e_fbc = factory.get_finite_bath_correction(c_bath, c_frozen)
             return c_bath, c_frozen, e_fbc
 
         c_bath_occ, c_frozen_occ, e_fbc_occ = get_orbitals('occupied')

--- a/vayesta/core/qemb/fragment.py
+++ b/vayesta/core/qemb/fragment.py
@@ -842,9 +842,10 @@ class Fragment:
             c_active_vir = self.canonicalize_mo(c_active_vir)[0]
         cluster = Cluster.from_coeffs(c_active_occ, c_active_vir, c_frozen_occ, c_frozen_vir)
         # Add finite bath correction to cluster object
-        cluster.e_fbc = e_fbc_occ + e_fbc_vir
+        cluster.e_fbc_occ = e_fbc_occ
+        cluster.e_fbc_vir = e_fbc_vir
         self.log.debug("Finite bath correction:  occ= %s  vir= %s  tot= %s", energy_string(e_fbc_occ),
-                       energy_string(e_fbc_vir), energy_string(cluster.e_fbc))
+                       energy_string(e_fbc_vir), energy_string(e_fbc_occ+e_fbc_vir))
 
         # Check occupations
         def check_occup(mo_coeff, expected):

--- a/vayesta/core/spinalg.py
+++ b/vayesta/core/spinalg.py
@@ -20,14 +20,15 @@ def add_numbers(*args):
 def hstack_matrices(*args, ignore_none=True):
     if ignore_none:
         args = [x for x in args if x is not None]
+    ndims = np.asarray([(arg[0].ndim+1) for arg in args])
     # RHF
-    if np.all([(arg[0].ndim == 1) for arg in args]):
+    if np.all(ndims == 2):
         return util.hstack(*args)
     # UHF
-    if np.all([(arg[0].ndim == 2) for arg in args]):
+    if np.all(ndims == 3):
         return (util.hstack(*[arg[0] for arg in args]),
                 util.hstack(*[arg[1] for arg in args]))
-    raise ValueError
+    raise ValueError("ndims= %r" % ndims)
 
 def dot(*args, out=None):
     """Generalizes dot with or without spin channel: ij,jk->ik or Sij,Sjk->Sik

--- a/vayesta/ewf/ewf.py
+++ b/vayesta/ewf/ewf.py
@@ -479,12 +479,20 @@ class EWF(Embedding):
         return e_corr / self.ncells
 
     @mpi.with_allreduce()
-    def get_finite_bath_correction(self):
+    def get_finite_bath_correction(self, occupied=True, virtual=True):
         e_fbc = 0.0
         # Only loop over fragments of own MPI rank
         for fx in self.get_fragments(active=True, sym_parent=None, mpi_rank=mpi.rank):
-            e_fbc += fx.symmetry_factor * fx.results.e_fbc
+            if occupied:
+                e_fbc += fx.symmetry_factor * fx.results.e_fbc_occ
+            if virtual:
+                e_fbc += fx.symmetry_factor * fx.results.e_fbc_vir
         return e_fbc/self.ncells
+
+    @with_doc(get_finite_bath_correction)
+    def get_fbc(self, *args, **kwargs):
+        """Alias for get_finite_bath_correction."""
+        return self.get_finite_bath_correction(*args, **kwargs)
 
     # Total energy
 

--- a/vayesta/ewf/ewf.py
+++ b/vayesta/ewf/ewf.py
@@ -478,6 +478,14 @@ class EWF(Embedding):
         e_corr = (e_singles + e_doubles)
         return e_corr / self.ncells
 
+    @mpi.with_allreduce()
+    def get_finite_bath_correction(self):
+        e_fbc = 0.0
+        # Only loop over fragments of own MPI rank
+        for fx in self.get_fragments(active=True, sym_parent=None, mpi_rank=mpi.rank):
+            e_fbc += fx.symmetry_factor * fx.results.e_fbc
+        return e_fbc/self.ncells
+
     # Total energy
 
     @property

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -70,7 +70,9 @@ class Fragment(BaseFragment):
     @dataclasses.dataclass
     class Results(BaseFragment.Results):
         e_corr_dm2cumulant: float = None
-        e_fbc: float = None                 # Finite bath correction
+        # Finite bath correction
+        e_fbc_occ: float = None
+        e_fbc_vir: float = None
         n_active: int = None
         ip_energy: np.ndarray = None
         ea_energy: np.ndarray = None
@@ -281,9 +283,12 @@ class Fragment(BaseFragment):
         self._results = results = self.Results(fid=self.id, n_active=cluster.norb_active,
                 converged=cluster_solver.converged, wf=cluster_solver.wf, pwf=pwf)
         # --- Finite bath correction
-        e_fbc = getattr(cluster, 'e_fbc', None)
-        if e_fbc is not None:
-            self._results.e_fbc = e_fbc
+        e_fbc_occ = getattr(cluster, 'e_fbc_occ', None)
+        e_fbc_vir = getattr(cluster, 'e_fbc_vir', None)
+        if e_fbc_occ is not None:
+            self._results.e_fbc_occ = e_fbc_occ
+        if e_fbc_vir is not None:
+            self._results.e_fbc_vir = e_fbc_vir
 
         # --- Correlation energy contributions
         if self.opts.calc_e_wf_corr:

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -46,8 +46,6 @@ class Options(BaseFragment.Options):
     # Calculation modes
     calc_e_wf_corr: bool = None
     calc_e_dm_corr: bool = None
-    # Intercluster MP2
-    icmp2_active: bool = None               # If True, the fragment is used in the intercluster MP2 correction
     # Fragment specific
     # -----------------
     wf_factor: Optional[int] = None

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -68,9 +68,6 @@ class Fragment(BaseFragment):
     @dataclasses.dataclass
     class Results(BaseFragment.Results):
         e_corr_dm2cumulant: float = None
-        # Finite bath correction
-        e_fbc_occ: float = None
-        e_fbc_vir: float = None
         n_active: int = None
         ip_energy: np.ndarray = None
         ea_energy: np.ndarray = None
@@ -280,13 +277,6 @@ class Fragment(BaseFragment):
         # --- Add to results data class
         self._results = results = self.Results(fid=self.id, n_active=cluster.norb_active,
                 converged=cluster_solver.converged, wf=cluster_solver.wf, pwf=pwf)
-        # --- Finite bath correction
-        e_fbc_occ = getattr(cluster, 'e_fbc_occ', None)
-        e_fbc_vir = getattr(cluster, 'e_fbc_vir', None)
-        if e_fbc_occ is not None:
-            self._results.e_fbc_occ = e_fbc_occ
-        if e_fbc_vir is not None:
-            self._results.e_fbc_vir = e_fbc_vir
 
         # --- Correlation energy contributions
         if self.opts.calc_e_wf_corr:

--- a/vayesta/ewf/icmp2.py
+++ b/vayesta/ewf/icmp2.py
@@ -46,7 +46,7 @@ class ClusterUHF:
 
 
 def _get_icmp2_fragments(emb, **kwargs):
-        return emb.get_fragments(active=True, options=dict(icmp2_active=True), **kwargs)
+        return emb.get_fragments(active=True, flags=dict(is_envelop=True), **kwargs)
 
 
 def get_intercluster_mp2_energy_rhf(emb, bno_threshold_occ=None, bno_threshold_vir=1e-9,

--- a/vayesta/tests/ewf/test_fbc.py
+++ b/vayesta/tests/ewf/test_fbc.py
@@ -1,0 +1,65 @@
+import unittest
+import vayesta
+import vayesta.ewf
+from vayesta.core.util import cache
+from vayesta.tests import testsystems
+from vayesta.tests.common import TestCase
+
+
+class Test_Restricted(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.water_631g.rhf()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mf
+        cls.emb.cache_clear()
+
+    @classmethod
+    @cache
+    def emb(cls, bno_threshold):
+        emb = vayesta.ewf.EWF(cls.mf, bath_options=dict(threshold=bno_threshold))
+        emb.kernel()
+        return emb
+
+    def test_full_bath(self):
+        emb = self.emb(-1)
+        self.assertAllclose(emb.get_fbc_energy(), 0)
+
+    def test_finite_bath(self):
+        emb = self.emb(1e-3)
+        self.assertAllclose(emb.get_fbc_energy(), -0.00965818665787619)
+
+    def test_finite_bath_occ(self):
+        emb = self.emb(1e-3)
+        self.assertAllclose(emb.get_fbc_energy(virtual=False), -0.000749028286918895)
+
+    def test_finite_bath_vir(self):
+        emb = self.emb(1e-3)
+        self.assertAllclose(emb.get_fbc_energy(occupied=False), -0.00890915837083031)
+
+
+class Test_Unrestricted(Test_Restricted):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.water_cation_631g.uhf()
+
+    def test_finite_bath(self):
+        emb = self.emb(1e-3)
+        self.assertAllclose(emb.get_fbc_energy(), -0.009390484069477173)
+
+    def test_finite_bath_occ(self):
+        emb = self.emb(1e-3)
+        self.assertAllclose(emb.get_fbc_energy(virtual=False), -0.0005469048120275064)
+
+    def test_finite_bath_vir(self):
+        emb = self.emb(1e-3)
+        self.assertAllclose(emb.get_fbc_energy(occupied=False), -0.008843579257449625)
+
+
+if __name__ == '__main__':
+    print('Running %s' % __file__)
+    unittest.main()


### PR DESCRIPTION
This add a finite bath (energy) correction ("FBC"), which can be calculated using `ewf.get_fbc_energy()`.

The correction is calculated from the subspace MP2 calculations independently for the finite occupied and finite virtual bath, as described in my PhD thesis. It can be combined with the secondary fragment ("delta-MP2") correction.

The cost of the calculation is dominated by N^3 per fragment integral transformation, which is the same cost as the integral transformation needed for each BNO bath (storing these integrals would be a possibility, but would likely require too much memory ni most scenarios).  

The correction can in principle be also added to the DM-energy, in the sense that the limits are correct and the contributions are in principle not overcounting anything.