### PR TITLE
Adds project_dmet_order for BNO bath

### DIFF
--- a/vayesta/core/qemb/fragment.py
+++ b/vayesta/core/qemb/fragment.py
@@ -799,14 +799,16 @@ class Fragment:
                 return R2_Bath(self, dmet, occtype=occtype)
             # MP2 bath natural orbitals
             if btype == 'mp2':
-                project_dmet = self._get_bath_option('project_dmet', occtype)
+                project_dmet_order = self._get_bath_option('project_dmet_order', occtype)
+                project_dmet_mode = self._get_bath_option('project_dmet_mode', occtype)
                 addbuffer = self._get_bath_option('addbuffer', occtype) and occtype == 'virtual'
                 if addbuffer:
                     other = 'occ' if (otype == 'vir') else 'vir'
                     c_buffer = getattr(dmet, 'c_env_%s' % other)
                 else:
                     c_buffer = None
-                return MP2_Bath(self, dmet_bath=dmet, occtype=occtype, c_buffer=c_buffer, project_dmet=project_dmet)
+                return MP2_Bath(self, dmet_bath=dmet, occtype=occtype, c_buffer=c_buffer,
+                                project_dmet_order=project_dmet_order, project_dmet_mode=project_dmet_mode)
             raise NotImplementedError('bathtype= %s' % btype)
         self._bath_factory_occ = get_bath(occtype='occupied')
         self._bath_factory_vir = get_bath(occtype='virtual')

--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -74,7 +74,7 @@ class Options(OptionsBase):
         # R2 bath
         rcut=None, unit='Ang',
         # MP2 bath
-        threshold=None, truncation='occupation', project_dmet=False, addbuffer=False,
+        threshold=None, truncation='occupation', project_dmet_order=0, project_dmet_mode='full', addbuffer=False,
         # General
         canonicalize=True,
         # The following options can be set occupied/virtual-specific:
@@ -83,7 +83,8 @@ class Options(OptionsBase):
         unit_occ=None, unit_vir=None,
         threshold_occ=None, threshold_vir=None,
         truncation_occ=None, truncation_vir=None,
-        project_dmet_occ=None, bathtype_dmet_vir=None,
+        project_dmet_order_occ=None, project_dmet_order_vir=None,
+        project_dmet_mode_occ=None, project_dmet_mode_vir=None,
         addbuffer_occ=None, addbuffer_dmet_vir=None,
         canonicalize_occ=None, canonicalize_vir=None,
         )


### PR DESCRIPTION
Replaces the option `project_dmet` of the BNO bath with the options `project_dmet_order` and `project_dmet_mode` - 
the latter defines the mode of projection (e.g. 'full', or 'linear') and the former is 0, 1, or 2, applying 0, 1, or 2 projectors or the MP2 T2 amplitudes respectively.