### PR TITLE
Adds contraction of 2-DM intermediates for RHF

### DIFF
--- a/vayesta/core/ao2mo/helper.py
+++ b/vayesta/core/ao2mo/helper.py
@@ -164,6 +164,7 @@ def get_ovvv(eris, block='ovvv'):
     govvv = govvv.reshape(nocc,nvir,nvir,nvir)
     return govvv
 
+
 def get_ovVV(eris, block='ovVV'):
     sl, sr = (0, 1) if block == 'ovVV' else (1, 0)
     nmoL = eris.fock[sl].shape[-1]
@@ -179,6 +180,7 @@ def get_ovVV(eris, block='ovVV'):
     govvv = pyscf.lib.unpack_tril(govvv.reshape(noccL*nvirL, nvir_pair))
     govvv = govvv.reshape(noccL,nvirL,nvirR,nvirR)
     return govvv
+
 
 def get_vvvv(eris, block='vvvv'):
     if hasattr(eris, 'VVVV'):
@@ -204,6 +206,7 @@ def get_vvvv(eris, block='vvvv'):
     gvvvv = einsum('ijQ,klQ->ijkl', vvl, vvl)
     return gvvvv
 
+
 def get_vvVV(eris, block='vvVV'):
     sl, sr = ((0, 1) if block == 'vvVV' else (1, 0))
     nmoL = eris.fock[sl].shape[-1]
@@ -223,6 +226,7 @@ def get_vvVV(eris, block='vvVV'):
             return pyscf.lib.unpack_tril(xVV[:], axis=1).reshape(nvirL,nvirL,nvirR,nvirR)
     raise NotImplementedError
 
+
 def get_block(eris, block):
     if block in ['ovvv', 'OVVV']:
         return get_ovvv(eris, block=block)
@@ -234,14 +238,17 @@ def get_block(eris, block):
         return get_vvVV(eris, block=block)
     return getattr(eris, block)
 
+
 def pack_ovvv(ovvv):
     nocc, nvir = ovvv.shape[:2]
     ovvv = pyscf.lib.pack_tril(ovvv.reshape(nocc*nvir, nvir, nvir))
     return ovvv.reshape(nocc, nvir, -1)
 
+
 def pack_vvvv(vvvv):
     nvir = vvvv.shape[0]
     return pyscf.ao2mo.restore(4, vvvv, nvir)
+
 
 def contract_dm2_eris(dm2, eris):
     """Contracts _ChemistsERIs with the two-body density matrix.
@@ -290,14 +297,21 @@ def contract_dm2_eris_rhf(dm2, eris):
     """
     nocc = eris.oooo.shape[0]
     o, v = np.s_[:nocc], np.s_[nocc:]
-    e2 = 0
-    e2 += _contract_4d(dm2[o,o,o,o], eris.oooo)
-    e2 += _contract_4d(dm2[o,v,o,o], eris.ovoo) * 4
-    e2 += _contract_4d(dm2[o,o,v,v], eris.oovv) * 2
-    e2 += _contract_4d(dm2[o,v,o,v], eris.ovov) * 2
-    e2 += _contract_4d(dm2[o,v,v,o], eris.ovvo) * 2
-    e2 += _contract_4d(dm2[o,v,v,v], get_ovvv(eris)) * 4
-    e2 += _contract_4d(dm2[v,v,v,v], get_vvvv(eris))
+    e_oooo = _contract_4d(dm2[o,o,o,o], eris.oooo)
+    e_ovoo = _contract_4d(dm2[o,v,o,o], eris.ovoo) * 4
+    e_oovv = _contract_4d(dm2[o,o,v,v], eris.oovv) * 2
+    e_ovov = _contract_4d(dm2[o,v,o,v], eris.ovov) * 2
+    e_ovvo = _contract_4d(dm2[o,v,v,o], eris.ovvo) * 2
+    e_ovvv = _contract_4d(dm2[o,v,v,v], get_ovvv(eris)) * 4
+    e_vvvv = _contract_4d(dm2[v,v,v,v], get_vvvv(eris))
+    log.debugv("E(oooo)= %s", energy_string(e_oooo))
+    log.debugv("E(ovoo)= %s", energy_string(e_ovoo))
+    log.debugv("E(oovv)= %s", energy_string(e_oovv))
+    log.debugv("E(ovov)= %s", energy_string(e_ovov))
+    log.debugv("E(ovvo)= %s", energy_string(e_ovvo))
+    log.debugv("E(ovvv)= %s", energy_string(e_ovvv))
+    log.debugv("E(vvvv)= %s", energy_string(e_vvvv))
+    e2 = e_oooo + e_ovoo + e_oovv + e_ovov + e_ovvo + e_ovvv + e_vvvv
     return e2
 
 
@@ -355,6 +369,15 @@ def contract_dm2_eris_uhf(dm2, eris):
     return e2
 
 
+# Order used in PySCF for 2-DM intermediates:
+dm2intermeds = ['ovov', 'vvvv', 'oooo', 'oovv', 'ovvo', 'vvov', 'ovvv', 'ooov',]
+
+
+def _dm2intermeds_to_dict_rhf(dm2):
+    dm2dict = {block: dm2[idx] for (idx, block) in enumerate(dm2intermeds)}
+    return dm2dict
+
+
 def _dm2intermeds_to_dict_uhf(dm2):
     dm2dict = {}
 
@@ -366,26 +389,58 @@ def _dm2intermeds_to_dict_uhf(dm2):
         dm2dict[b0.upper() + b1.lower()] = np.asarray(dm2i[2])
         dm2dict[block.upper()] = np.asarray(dm2i[3])
 
-    _add_spinblocks('ovov', 0)
-    _add_spinblocks('vvvv', 1)
-    _add_spinblocks('oooo', 2)
-    _add_spinblocks('oovv', 3)
-    _add_spinblocks('ovvo', 4)
-    _add_spinblocks('vvov', 5)
-    _add_spinblocks('ovvv', 6)
-    _add_spinblocks('ooov', 7)
+    for idx, block in enumerate(dm2intermeds):
+        _add_spinblocks(block, idx)
     return dm2dict
+
+
+def contract_dm2intermeds_eris_rhf(dm2, eris, destroy_dm2=True):
+    """Contracts _ChemistsERIs with the two-body density matrix.
+
+    Parameters
+    ----------
+    dm2 : tuple
+        Intermediates of spin-restricted two-body density matrix.
+    eris : _ChemistERIs
+        PySCF ERIs object.
+
+    Returns
+    -------
+    e2 : float
+        Two-body energy.
+    """
+    dm2 = _dm2intermeds_to_dict_rhf(dm2)
+
+    def _get_block(block, keep=False):
+        if destroy_dm2 and not keep:
+            return dm2.pop(block)
+        return dm2[block]
+
+    e_oooo = _contract_4d(_get_block('oooo'), eris.oooo) * 4
+    e_ovoo = _contract_4d(_get_block('ooov'), eris.ovoo, transpose=(2,3,0,1)) * 4
+    e_oovv = _contract_4d(_get_block('oovv'), eris.oovv) * 4
+    e_ovov = _contract_4d(_get_block('ovov'), eris.ovov) * 4
+    e_ovvo = _contract_4d(_get_block('ovvo'), eris.ovvo) * 4
+    e_ovvv = _contract_4d(_get_block('ovvv'), get_ovvv(eris)) * 4
+    e_vvvv = _contract_4d(_get_block('vvvv'), get_vvvv(eris)) * 4
+    log.debugv("E(oooo)= %s", energy_string(e_oooo))
+    log.debugv("E(ovoo)= %s", energy_string(e_ovoo))
+    log.debugv("E(oovv)= %s", energy_string(e_oovv))
+    log.debugv("E(ovov)= %s", energy_string(e_ovov))
+    log.debugv("E(ovvo)= %s", energy_string(e_ovvo))
+    log.debugv("E(ovvv)= %s", energy_string(e_ovvv))
+    log.debugv("E(vvvv)= %s", energy_string(e_vvvv))
+    e2 = e_oooo + e_ovoo + e_oovv + e_ovov + e_ovvo + e_ovvv + e_vvvv
+    return e2
 
 
 def contract_dm2intermeds_eris_uhf(dm2, eris, destroy_dm2=True):
     """Contracts _ChemistsERIs with the two-body density matrix.
 
-    TODO: RHF
-
     Parameters
     ----------
     dm2 : tuple
-        Intermediates of two-body density matrix.
+        Intermediates of spin-unrestricted two-body density matrix.
     eris : _ChemistERIs
         PySCF ERIs object.
 
@@ -405,7 +460,8 @@ def contract_dm2intermeds_eris_uhf(dm2, eris, destroy_dm2=True):
     # Alpha-alpha
     e2 += _contract_4d(_get_block('oooo'), eris.oooo)
     e2 += _contract_4d(_get_block('ooov'), eris.ovoo, transpose=(2,3,0,1)) * 4
-    e2 += _contract_4d(_get_block('ovvo', keep=True), eris.oovv, transpose=(0,3,2,1)) * -2
+    #e2 += _contract_4d(_get_block('ovvo', keep=True), eris.oovv, transpose=(0,3,2,1)) * -2
+    e2 += _contract_4d(_get_block('oovv'), eris.oovv) * 2
     e2 += _contract_4d(_get_block('ovov'), eris.ovov) * 2
     e2 += _contract_4d(_get_block('ovvo'), eris.ovvo) * 2
     e2 += _contract_4d(_get_block('ovvv'), get_ovvv(eris)) * 4
@@ -413,7 +469,8 @@ def contract_dm2intermeds_eris_uhf(dm2, eris, destroy_dm2=True):
     # Beta-beta
     e2 += _contract_4d(_get_block('OOOO'), eris.OOOO)
     e2 += _contract_4d(_get_block('OOOV'), eris.OVOO, transpose=(2,3,0,1)) * 4
-    e2 += _contract_4d(_get_block('OVVO', keep=True), eris.OOVV, transpose=(0,3,2,1)) * -2
+    #e2 += _contract_4d(_get_block('OVVO', keep=True), eris.OOVV, transpose=(0,3,2,1)) * -2
+    e2 += _contract_4d(_get_block('OOVV'), eris.OOVV) * 2
     e2 += _contract_4d(_get_block('OVOV'), eris.OVOV) * 2
     e2 += _contract_4d(_get_block('OVVO'), eris.OVVO) * 2
     e2 += _contract_4d(_get_block('OVVV'), get_ovvv(eris, block='OVVV')) * 4
@@ -525,6 +582,7 @@ def project_ccsd_eris(eris, mo_coeff, nocc, ovlp, check_subspace=True):
     eris.fock = dot(r_all, eris.fock, r_all.T)
     eris.mo_energy = np.diag(eris.fock)
     return eris
+
 
 if __name__ == '__main__':
     def test1():

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -414,6 +414,7 @@ class Fragment(BaseFragment):
         return t1, t2, l1, l2, t1x, t2x, l1x, l2x
 
     def _get_projected_gamma1_intermediates(self, t_as_lambda=False, sym_t2=True):
+        """Intermediates for 1-DM, projected in Lambda-amplitudes and linear T-term."""
         t1, t2, l1, l2, t1x, t2x, l1x, l2x = self._ccsd_amplitudes_for_dm(t_as_lambda=t_as_lambda, sym_t2=sym_t2)
         doo, dov, dvo, dvv = pyscf.cc.ccsd_rdm._gamma1_intermediates(None, t1, t2, l1x, l2x)
         # Correction for term without Lambda amplitude:
@@ -422,6 +423,7 @@ class Fragment(BaseFragment):
         return d1
 
     def _get_projected_gamma2_intermediates(self, t_as_lambda=False, sym_t2=True):
+        """Intermediates for 2-DM, projected in Lambda-amplitudes and linear T-term."""
         t1, t2, l1, l2, t1x, t2x, l1x, l2x = self._ccsd_amplitudes_for_dm(t_as_lambda=t_as_lambda, sym_t2=sym_t2)
         cc = self.mf # Only attributes stdout, verbose, and max_memory are needed, just use mean-field object
         dovov, *d2rest = pyscf.cc.ccsd_rdm._gamma2_intermediates(cc, t1, t2, l1x, l2x)
@@ -493,9 +495,9 @@ class Fragment(BaseFragment):
         dm2 = self.make_fragment_dm2cumulant(t_as_lambda=t_as_lambda, sym_t2=sym_t2, approx_cumulant=approx_cumulant,
                 full_shape=False)
         # CCSD
-        # TODO: contract intermediates (see UHF version)
         if hasattr(eris, 'ovoo'):
-            return vayesta.core.ao2mo.helper.contract_dm2_eris(dm2, eris)/2
+            d2 = self._get_projected_gamma2_intermediates(t_as_lambda=t_as_lambda, sym_t2=sym_t2)
+            return vayesta.core.ao2mo.helper.contract_dm2intermeds_eris_rhf(d2, eris)/2
         fac = (2 if self.solver == 'MP2' else 1)
         e_dm2 = fac*einsum('ijkl,ijkl->', eris, dm2)/2
         return e_dm2

--- a/vayesta/ewf/ufragment.py
+++ b/vayesta/ewf/ufragment.py
@@ -116,15 +116,11 @@ class Fragment(RFragment, BaseFragment):
         e_corr = (e_singles + e_doubles)
         return e_singles, e_doubles, e_corr
 
+    @with_doc(RFragment._get_projected_gamma1_intermediates)
     def _get_projected_gamma1_intermediates(self, t_as_lambda=None, sym_t2=True):
         raise NotImplementedError
-        t1, t2, l1, l2, t1x, t2x, l1x, l2x = self._ccsd_amplitudes_for_dm(t_as_lambda=t_as_lambda, sym_t2=sym_t2)
-        doo, dov, dvo, dvv = pyscf.cc.uccsd_rdm._gamma1_intermediates(None, t1, t2, l1x, l2x)
-        # Correction for term without Lambda amplitude:
-        #dvo += (t1x - t1).T
-        #d1 = (doo, dov, dvo, dvv)
-        #return d1
 
+    @with_doc(RFragment._get_projected_gamma2_intermediates)
     def _get_projected_gamma2_intermediates(self, t_as_lambda=None, sym_t2=True):
         t1, t2, l1, l2, t1x, t2x, l1x, l2x = self._ccsd_amplitudes_for_dm(t_as_lambda=t_as_lambda, sym_t2=sym_t2)
         # Only incore for UCCSD:
@@ -186,7 +182,6 @@ class Fragment(RFragment, BaseFragment):
             eris = self.base.get_eris_array_uhf(self.cluster.c_active)
         # For CCSD we can contract the ERIs with the DM2-intermediates
         if hasattr(eris, 'ovoo'):
-            cc = d1 = None
             d2 = self._get_projected_gamma2_intermediates(t_as_lambda=t_as_lambda, sym_t2=sym_t2)
             return vayesta.core.ao2mo.helper.contract_dm2intermeds_eris_uhf(d2, eris)/2
         # TODO: other solvers


### PR DESCRIPTION
This avoids building the full cluster 2-DM cumulant to calculate the DM-energy, and instead contracts only the occ^4, occ^3*vir, ... ,vir^4 subblocks, one at a time, saving memory. The same is already implemented for UHF.