### PR TITLE
Adds CISD initial guess for CCSD

### DIFF
--- a/examples/ewf/molecules/01-simple-ccsd.py
+++ b/examples/ewf/molecules/01-simple-ccsd.py
@@ -13,7 +13,7 @@ H  0.0000   0.7572  -0.4692
 H  0.0000  -0.7572  -0.4692
 """
 mol.basis = 'cc-pVDZ'
-mol.output = 'pyscf.out'
+mol.output = 'pyscf.txt'
 mol.build()
 
 # Hartree-Fock

--- a/vayesta/solver/ccsd.py
+++ b/vayesta/solver/ccsd.py
@@ -14,11 +14,12 @@ from vayesta.core.types import Orbitals
 from vayesta.core.types import WaveFunction
 from vayesta.core.types import CCSD_WaveFunction
 from vayesta.core.qemb import scrcoulomb
-from .solver import ClusterSolver
-from . import coupling
-from . import tccsd
 from vayesta.core.ao2mo import helper
 from vayesta.core.util import *
+from .solver import ClusterSolver
+
+from . import coupling
+from . import tccsd
 
 
 class CCSD_Solver(ClusterSolver):
@@ -29,6 +30,7 @@ class CCSD_Solver(ClusterSolver):
         maxiter: int = 100              # Max number of iterations
         conv_tol: float = None          # Convergence energy tolerance
         conv_tol_normt: float = None    # Convergence amplitude tolerance
+        init_guess: str = 'MP2'         # ['MP2', 'CISD']
         # Self-consistent mode
         sc_mode: int = None
         # DM
@@ -73,6 +75,10 @@ class CCSD_Solver(ClusterSolver):
             return pyscf.cc.dfccsd.RCCSD
         return pyscf.cc.ccsd.CCSD
 
+    def get_cisd_solver(self):
+        from vayesta.solver import CISD_Solver
+        return CISD_Solver
+
     def reset(self):
         super().reset()
         self.eris = None
@@ -83,8 +89,16 @@ class CCSD_Solver(ClusterSolver):
             self.eris = self.base.get_eris_object(self.solver)
         return self.eris
 
-    def get_init_guess(self):
-        return {'t1' : self.t1 , 't2' : self.t2}
+    def get_init_guess(self, eris=None):
+        if self.opts.init_guess in ('default', 'MP2'):
+            # CCSD will build MP2 amplitudes
+            return None, None
+        if self.opts.init_guess == 'CISD':
+            cisd = self.get_cisd_solver()(self.mf, self.fragment, self.cluster)
+            cisd.kernel(eris=eris)
+            wf = cisd.wf.as_ccsd()
+            return wf.t1, wf.t2
+        raise ValueError("init_guess= %r" % self.opts.init_guess)
 
     def add_screening(self, *args, **kwargs):
         raise NotImplementedError("Screening only implemented for unrestricted spin-symmetry.")
@@ -151,7 +165,12 @@ class CCSD_Solver(ClusterSolver):
             self.set_callback(coupling.make_cross_fragment_tcc_function(self, mode=(self.opts.sc_mode or 3),
                               coupled_fragments=coupled_fragments))
 
-        self.log.info("Solving CCSD-equations %s initial guess...", "with" if (t2 is not None) else "without")
+        # Initial guess
+        if t1 is not None or t2 is not None:
+            self.log.info("Solving CCSD-equations with initial guess...")
+        else:
+            t1, t2 = self.get_init_guess(eris=eris)
+
         with log_time(self.log.info, "Time for T-equations: %s"):
             self.solver.kernel(t1=t1, t2=t2, eris=eris)
         if not self.solver.converged:
@@ -253,6 +272,10 @@ class UCCSD_Solver(CCSD_Solver):
         if self.base.pbc_dimension > 0:
             return pyscf.pbc.cc.ccsd.UCCSD
         return pyscf.cc.uccsd.UCCSD
+
+    def get_cisd_solver(self):
+        from vayesta.solver import UCISD_Solver
+        return UCISD_Solver
 
     @deprecated()
     def get_c2(self, intermed_norm=True):

--- a/vayesta/solver/cisd.py
+++ b/vayesta/solver/cisd.py
@@ -2,11 +2,11 @@ import pyscf
 import pyscf.ci
 from vayesta.core.util import *
 from vayesta.core.types import WaveFunction
-from .ccsd import CCSD_Solver
+import vayesta.solver.ccsd as ccsd
 from .solver import ClusterSolver
 
 
-class CISD_Solver(CCSD_Solver):
+class CISD_Solver(ccsd.CCSD_Solver):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/vayesta/tests/dmet/test_molecule.py
+++ b/vayesta/tests/dmet/test_molecule.py
@@ -66,7 +66,7 @@ class MoleculeTest(TestCase):
         """Test H6 STO-6G with FCI solver, IAO fragmentation and no charge consistency.
         """
         emb = dmet.DMET(testsystems.h6_sto6g.rhf(), solver='CCSD', charge_consistent=False,
-                bath_options=dict(bathtype='dmet'), conv_tol=self.CONV_TOL, solver_options=FCI_SOLVER_OPTS)
+                bath_options=dict(bathtype='dmet'), conv_tol=self.CONV_TOL)
         with emb.iao_fragmentation() as f:
             f.add_atomic_fragment([0, 1])
             f.add_atomic_fragment([2, 3])


### PR DESCRIPTION
This adds CISD as an initial guess for the CCSD solver.
Syntax:
`solver_options=dict(init_guess='CISD')`