### PR TITLE
Adds tailoring tests, deactivates fix_spin for UFCI

### DIFF
--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -101,7 +101,7 @@ class Options(OptionsBase):
             # CCSD
             solve_lambda=True, conv_tol_normt=None,
             # FCI
-            threads=1, max_cycle=300, fix_spin=0.0, lindep=None,
+            threads=1, max_cycle=300, fix_spin=None, lindep=None,
             davidson_only=True, init_guess='default',
             # EBFCI/EBCCSD
             max_boson_occ=2,

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -298,9 +298,9 @@ class Fragment(BaseFragment):
 
     def get_solver_options(self, solver):
         # TODO: fix this mess...
-        solver_opts = {}
-        # conv_tol, max_cycle, solve_lambda,...:
-        solver_opts.update(self.opts.solver_options)
+        # Use those values from solver_options, which are not None
+        # (conv_tol, max_cycle, solve_lambda,...)
+        solver_opts = {key: val for (key, val) in self.opts.solver_options.items() if val is not None}
         pass_through = []
         if 'CCSD' in solver.upper():
             pass_through += ['sc_mode', 'dm_with_frozen']

--- a/vayesta/tests/ewf/test_tailoring.py
+++ b/vayesta/tests/ewf/test_tailoring.py
@@ -1,0 +1,96 @@
+import unittest
+import numpy as np
+import vayesta
+import vayesta.ewf
+from vayesta.core.util import cache
+from vayesta.tests import testsystems
+from vayesta.tests.common import TestCase
+
+
+class TestRestricted(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.n2_sto_150pm.rhf()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mf
+        cls.emb.cache_clear()
+
+    @classmethod
+    @cache
+    def emb(cls, bno_threshold, tailoring):
+        solver_opts = dict(conv_tol= 1e-12, conv_tol_normt=1e-8, solve_lambda=False)
+        emb = vayesta.ewf.EWF(cls.mf, bath_options=dict(threshold=bno_threshold), solver_options=solver_opts)
+        with emb.iao_fragmentation() as f:
+            fci1 = f.add_atomic_fragment(0, solver='FCI', bath_options=dict(bathtype='dmet'))
+            fci2 = f.add_atomic_fragment(1, solver='FCI', bath_options=dict(bathtype='dmet'))
+            ccsd1 = f.add_atomic_fragment(0, active=False)
+            ccsd2 = f.add_atomic_fragment(1, active=False)
+        # Solve FCI
+        emb.kernel()
+        fci1.active = fci2.active = False
+        ccsd1.active = ccsd2.active = True
+        if tailoring == 'onsite':
+            ccsd1.tailor_with_fragments([fci1], project=0)
+            ccsd2.tailor_with_fragments([fci2], project=0)
+        elif tailoring == 'all-1p':
+            ccsd1.tailor_with_fragments([fci1, fci2], project=1)
+            ccsd2.tailor_with_fragments([fci1, fci2], project=1)
+        else:
+            raise ValueError
+        # Solve (tailored) CCSD
+        emb.kernel()
+        return emb
+
+    def test_wf_energy_onsite(self):
+        emb = self.emb(1e-4, 'onsite')
+        self.assertAllclose(emb.e_corr, -0.43332813177760987, atol=1e-6, rtol=0)
+
+    def test_dm_energy_onsite(self):
+        emb = self.emb(1e-4, 'onsite')
+        self.assertAllclose(emb.get_dm_corr_energy(), -0.4073623273252255, atol=1e-6, rtol=0)
+
+    def test_wf_energy_all(self):
+        emb = self.emb(1e-4, 'all-1p')
+        self.assertAllclose(emb.e_corr, -0.43328577969028964, atol=1e-6, rtol=0)
+
+    def test_dm_energy_all(self):
+        emb = self.emb(1e-4, 'all-1p')
+        self.assertAllclose(emb.get_dm_corr_energy(), -0.4067136384165535, atol=1e-6, rtol=0)
+
+
+class TestUnrestrictedS0(TestRestricted):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.n2_sto_150pm.rhf().to_uhf()
+
+
+class TestUnrestrictedS4(TestRestricted):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.n2_sto_s4_150pm.uhf()
+
+    def test_wf_energy_onsite(self):
+        emb = self.emb(1e-4, 'onsite')
+        self.assertAllclose(emb.e_corr, -0.20294262284592862, atol=1e-6, rtol=0)
+
+    def test_dm_energy_onsite(self):
+        emb = self.emb(1e-4, 'onsite')
+        self.assertAllclose(emb.get_dm_corr_energy(), -0.2187131950991378, atol=1e-6, rtol=0)
+
+    def test_wf_energy_all(self):
+        emb = self.emb(1e-4, 'all-1p')
+        self.assertAllclose(emb.e_corr, -0.20279235812388702, atol=1e-6, rtol=0)
+
+    def test_dm_energy_all(self):
+        emb = self.emb(1e-4, 'all-1p')
+        self.assertAllclose(emb.get_dm_corr_energy(), -0.21845089572304, atol=1e-6, rtol=0)
+
+
+if __name__ == '__main__':
+    print('Running %s' % __file__)
+    unittest.main()

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -349,6 +349,10 @@ h3_ccpvdz_df = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0", basis="cc-p
 
 h6_dz = TestMolecule(atom=molecules.ring('H', 6, 1.0), basis='cc-pVDZ')
 
+atoms = 'N 0 0 -0.75; N 0 0 0.75'
+n2_sto_150pm = TestMolecule(atoms, basis='cc-pvdz')
+n2_sto_s4_150pm = TestMolecule(atoms, basis='cc-pvdz', spin=4)
+
 n2_ccpvdz_df = TestMolecule("N1 0 0 0; N2 0 0 1.1", basis="cc-pvdz", auxbasis="cc-pvdz-jkfit")
 
 f2_sto6g = TestMolecule(atom="F 0 0 0; F 0 0 1.2", basis='sto-6g')


### PR DESCRIPTION
PySCF's `fix_spin_` decorator for FCI seems to produce non-deterministic results when used with UHF orbitals.