### PR TITLE
Fix afm single site

### DIFF
--- a/vayesta/core/types/wf/fci.py
+++ b/vayesta/core/types/wf/fci.py
@@ -69,6 +69,10 @@ class RFCI_WaveFunction(wf_types.WaveFunction):
             raise NotImplementedError
         norb, nocc, nvir = self.norb, self.nocc, self.nvir
         t1addr, t1sign = pyscf.ci.cisd.t1strs(norb, nocc)
+
+        # Change to arrays, in case of empty slice
+        t1addr = np.asarray(t1addr, dtype=int)
+
         c1 = self.ci[0,t1addr] * t1sign
         c2 = einsum('i,j,ij->ij', t1sign, t1sign, self.ci[t1addr[:,None],t1addr])
         c1 = c1.reshape(nocc,nvir)
@@ -221,6 +225,11 @@ class UFCI_WaveFunction(RFCI_WaveFunction):
         t1addrb, t1signb = pyscf.ci.cisd.tn_addrs_signs(norbb, noccb, 1)
         t2addra, t2signa = pyscf.ci.cisd.tn_addrs_signs(norba, nocca, 2)
         t2addrb, t2signb = pyscf.ci.cisd.tn_addrs_signs(norbb, noccb, 2)
+
+        # Change to arrays, in case of empty slice
+        t1addra = np.asarray(t1addra, dtype=int)
+        t1addrb = np.asarray(t1addrb, dtype=int)
+
         na = pyscf.fci.cistring.num_strings(norba, nocca)
         nb = pyscf.fci.cistring.num_strings(norbb, noccb)
 

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -174,16 +174,13 @@ class FCI_Solver(ClusterSolver):
         mo = Orbitals(self.cluster.c_active, occ=self.cluster.nocc_active)
         self.wf = FCI_WaveFunction(mo, self.civec)
 
-    #def get_cisd_amps(self, civec):
-    #    cisdvec = pyscf.ci.cisd.from_fcivec(civec, self.ncas, self.nelec)
-    #    c0, c1, c2 = pyscf.ci.cisd.cisdvec_to_amplitudes(cisdvec, self.ncas, self.cluster.nocc_active)
-    #    c1 = c1/c0
-    #    c2 = c2/c0
-    #    return c0, c1, c2
-
     def get_cisd_amps(self, civec, intermed_norm=False):
         nocc, nvir = self.cluster.nocc_active, self.cluster.nvir_active
         t1addr, t1sign = pyscf.ci.cisd.t1strs(self.ncas, nocc)
+
+        # Change to arrays, in case of empty slice
+        t1addr = np.asarray(t1addr, dtype=int)
+
         c0 = civec[0,0]
         c1 = civec[0,t1addr] * t1sign
         c2 = einsum('i,j,ij->ij', t1sign, t1sign, civec[t1addr[:,None],t1addr])
@@ -270,6 +267,11 @@ class UFCI_Solver(FCI_Solver):
         t1addrb, t1signb = pyscf.ci.cisd.tn_addrs_signs(norbb, noccb, 1)
         t2addra, t2signa = pyscf.ci.cisd.tn_addrs_signs(norba, nocca, 2)
         t2addrb, t2signb = pyscf.ci.cisd.tn_addrs_signs(norbb, noccb, 2)
+
+        # Change to arrays, in case of empty slice
+        t1addra = np.asarray(t1addra, dtype=int)
+        t1addrb = np.asarray(t1addrb, dtype=int)
+
         na = pyscf.fci.cistring.num_strings(norba, nocca)
         nb = pyscf.fci.cistring.num_strings(norbb, noccb)
 

--- a/vayesta/tests/ewf/test_h2.py
+++ b/vayesta/tests/ewf/test_h2.py
@@ -163,6 +163,30 @@ class Test_UFCI(TestCase):
         cls.mf = testsystems.h2anion_dz.uhf()
         cls.fci = testsystems.h2anion_dz.ufci()
 
+class Test_UFCI_dissoc(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.h2_sto3g_dissoc_df.uhf_stable()
+        cls.fci = testsystems.h2_sto3g_dissoc_df.ufci()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mf
+        del cls.fci
+        cls.emb.cache_clear()
+
+    @classmethod
+    @cache
+    def emb(cls, bno_threshold):
+        emb = vayesta.ewf.EWF(cls.mf, bath_options=dict(bathtype="dmet"), solver='FCI')
+        emb.kernel()
+        return emb
+
+    def test_energy(self):
+        emb = self.emb(-1)
+        self.assertAllclose(emb.e_tot, self.fci.e_tot, rtol=0)
+
 
 if __name__ == '__main__':
     print('Running %s' % __file__)

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -4,6 +4,7 @@ except ImportError:
     from functools import lru_cache
     cache = lru_cache(maxsize=None)
 import numpy as np
+import copy
 
 import pyscf
 # Open boundary
@@ -70,6 +71,24 @@ class TestMolecule:
         uhf.kernel()
         assert uhf.converged
         return uhf
+
+    @cache
+    def uhf_stable(self):
+        # Get uhf solution, and copy to avoid changing attributes.
+        uhf = copy.copy(self.uhf())
+        # Repeat this procedure a few times; it should converge pretty rapidly, but we don't want to get stuck in an
+        # infinite loop if it doesn't.
+        for i in range(5):
+            # Check stability of current solution.
+            int_c, ext_c, int_stab, ext_stab = uhf.stability(return_status=True)
+            # If we have a converged solution which is stable return.
+            if int_stab and uhf.converged:
+                return uhf
+            # Run new calculation starting from result of stability analysis.
+            uhf.kernel(dm0=uhf.make_rdm1(mo_coeff=int_c))
+        else:
+            # Don't want to get stuck in an infinite loop.
+            raise RuntimeError("Could not obtain converged, stable UHF solution.")
 
     # --- MP2
 
@@ -315,6 +334,7 @@ class TestLattice:
 
 h2_dz = TestMolecule("H 0 0 0; H 0 0 0.74", basis="cc-pvdz")
 h2anion_dz = TestMolecule("H 0 0 0; H 0 0 0.74", basis="cc-pvdz", charge=-1, spin=1)
+h2_sto3g_dissoc_df = TestMolecule("H 0 0 0; H 0 0 10.0", basis="sto3g", auxbasis=True)
 
 h6_sto6g = TestMolecule(
         atom=["H %f %f %f" % xyz for xyz in pyscf.tools.ring.make(6, 1.0)],


### PR DESCRIPTION
For a system which has strong AFM character running the default single-site EWF calculation in Vayesta with a spin-symmetry broken reference results in an error due to CISD coefficient generation on master. Here's is a minimal example using a dissociated hydrogen molecule, but I originally came across it in H-ring dissociations and I'd expect the same for the high-U Hubbard model.
```import vayesta.ewf
from pyscf import gto, scf
from vayesta.misc.molecules import ring

mol = gto.M()
mol.atom = "H  0  0  0;  H  0  0  10.0"
mol.basis="sto-3g"
mol.build()

umf = scf.UHF(mol).density_fit()
umf.kernel()
umf.kernel(dm0=umf.make_rdm1(mo_coeff=umf.stability()[0]))

uewf = vayesta.ewf.EWF(umf, solver="FCI", bath_options={"bathtype":"dmet"})
uewf.kernel()
```
from which I get the error
```
 Traceback (most recent call last):
  File "/home/charlie/calc/bugfix/cisd_amps/minex.py", line 18, in <module>
    uewf.kernel()
  File "/home/charlie/miniconda3/envs/vayesta/lib/python3.9/site-packages/vayesta/ewf/ewf.py", line 179, in kernel
    x.kernel()
  File "/home/charlie/miniconda3/envs/vayesta/lib/python3.9/site-packages/vayesta/ewf/fragment.py", line 293, in kernel
    cluster_solver.kernel(eris=eris, **init_guess)
  File "/home/charlie/miniconda3/envs/vayesta/lib/python3.9/site-packages/vayesta/solver/fci.py", line 164, in kernel
    self.c0, self.c1, self.c2 = self.get_cisd_amps(self.civec)
  File "/home/charlie/miniconda3/envs/vayesta/lib/python3.9/site-packages/vayesta/solver/fci.py", line 290, in get_cisd_amps
    c2ab = einsum('i,j,ij->ij', t1signa, t1signb, civec[t1addra[:,None],t1addrb])
TypeError: list indices must be integers or slices, not tuple
```
This arises because in these systems each cluster consists of a single occupied orbital of one spin, and a single virtual orbital of the other spin. This means that there are no valid excitations within the cluster, and so runs into an issue where the call to pyscf to obtain indexing and sign changes
```t1addra, t1signa = pyscf.ci.cisd.tn_addrs_signs(norba, nocca, 1)```
sets both variables to a zero-length list when there are no possible excitations, rather than a zero-length array which might be expected given the usual return value is an array. This then leads to a later error due to python lists not supporting zero-length indexing, unlike numpy arrays.

This has already come up in the `to_cisdtq` branch (where obtaining an empty list for the t3 and t4 indexing is a more common occurrence), so I've just borrowed the fix already implemented there to ensure these are always array-valued. Given `to_cisdtq` affects many of the same classes and is expected to be merged soon it seems more straightforward to add it here rather than to master.

This branch also adds a test for this case to avoid future regression. Doing this required a way to perform tests on a UHF solution which is stable under spin stability analysis, so I've added the `TestMolecule.uhf_stable()` functionality in `vayesta/tests/testsystems.py` for this purpose without breaking lots of existing UHF tests.