### PR TITLE
Run tests for PRs to all branches.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master, dev]
   pull_request:
-    branches: [master, dev]
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,3 +60,4 @@ jobs:
           publish_dir: docs/build/html
           force_orphan: true
         if: ${{ matrix.documentation && github.ref == 'refs/heads/master' && github.event_name != 'schedule' }}
+


### PR DESCRIPTION
Updates `ci.yaml` to triggers tests to run for all PRs, not just for those to `master` or `dev`.
If this doesn't work to target all PRs we could explicitly filter for all branches within `pull_request`, but that seems unnecessary if this removes filtering entirely.
