### PR TITLE
UHF on the 1D Hubbard model

### DIFF
--- a/vayesta/lattmod/latt.py
+++ b/vayesta/lattmod/latt.py
@@ -382,50 +382,6 @@ class LatticeRHF(LatticeSCF, pyscf.scf.hf.RHF):
         else:
             log.debugv("Mean-field site occupations=\n%r", occ)
 
-    #def kernel_hubbard(self):
-    #    mo_energy, mo_coeff = np.linalg.eigh(self.mol.h1e)
-    #    nocc = self.mol.nelectron//2
-    #    occ = np.s_[:nocc]
-    #    dm0 = 2*np.dot(mo_coeff[:,occ], mo_coeff[:,occ].T)
-    #    veff = self.get_veff(dm=dm0)
-    #    fock = self.get_hcore() + veff
-    #    mo_energy, mo_coeff = np.linalg.eigh(fock)
-    #    nvir = self.mol.nsite - nocc
-    #    self.mo_energy = mo_energy
-    #    log.info("MO energies:")
-    #    for i in range(0, len(mo_energy), 5):
-    #        e = mo_energy[i:i+5]
-    #        fmt = '  ' + len(e)*'  %+16.8f'
-    #        log.info(fmt, *e)
-    #    if nocc > 0:
-    #        homo = self.mo_energy[nocc-1]
-    #    else:
-    #        homo = np.nan
-    #    if nvir > 0:
-    #        lumo = self.mo_energy[nocc]
-    #    else:
-    #        lumo = np.nan
-    #    gap = (lumo-homo)
-    #    log.info("HOMO= %+16.8f  LUMO= %+16.8f  gap= %+16.8f", homo, lumo, gap)
-    #    if gap < 1e-8:
-    #        log.critical("Zero HOMO-LUMO gap!")
-    #        raise RuntimeError("Zero HOMO-LUMO gap!")
-    #    elif gap < 1e-2:
-    #        log.warning("Small HOMO-LUMO gap!")
-
-    #    self.mo_coeff = mo_coeff
-    #    self.mo_occ = np.asarray((nocc*[2] + nvir*[0]))
-
-    #    # Check lattice symmetry
-    #    dm = self.make_rdm1()
-    #    self.check_lattice_symmetry(dm)
-    #    veff = self.get_veff()
-    #    self.e_tot = np.einsum('ab,ba->', (self.get_hcore() + veff/2), dm)
-    #    self.converged = True
-
-    #    return self.e_tot
-
-    #kernel = kernel_hubbard
 
 class LatticeUHF(LatticeSCF, pyscf.scf.uhf.UHF):
 

--- a/vayesta/tests/edmet/test_dfedmet_hubbard.py
+++ b/vayesta/tests/edmet/test_dfedmet_hubbard.py
@@ -23,25 +23,25 @@ class HubbardDFEDMETTests(TestCase):
         emb = edmet.EDMET(
             testsystems.hubb_14_u4.rhf(),
             solver='EBFCI',
-            solver_options={"max_boson_occ":2},
+            solver_options={"max_boson_occ": 2},
             maxiter=1,
             max_elec_err=1e-6
         )
+        emb.symmetry.set_translations([7, 1, 1])
         with emb.site_fragmentation() as f:
-            frag = f.add_atomic_fragment([0, 1])
-            frag.add_tsymmetric_fragments(tvecs=[7, 1, 1])
+            f.add_atomic_fragment([0, 1])
         emb.kernel()
 
         dfedmet = edmet.EDMET(
             testsystems.hubb_14_u4_df.rhf(),
                 solver='EBFCI',
-                solver_options={"max_boson_occ":2},
+                solver_options={"max_boson_occ": 2},
                 maxiter=1,
                 max_elec_err=1e-6
         )
+        dfedmet.symmetry.set_translations([7, 1, 1])
         with dfedmet.site_fragmentation() as f:
-            frag = f.add_atomic_fragment([0, 1])
-            frag.add_tsymmetric_fragments(tvecs=[7, 1, 1])
+            f.add_atomic_fragment([0, 1])
         dfedmet.kernel()
         # This is the energy without the nonlocal correlation energy RPA correction.
         known_values = {'e_clus': -8.01015928145061, 'e_nl': -0.5338487284590787}

--- a/vayesta/tests/edmet/test_edmet_hubbard.py
+++ b/vayesta/tests/edmet/test_edmet_hubbard.py
@@ -13,42 +13,42 @@ class EDMET_Hubbard_Tests(TestCase):
         """
         self.assertAlmostEqual(emb.e_tot, known_values['e_tot'], self.PLACES_ENERGY)
 
-    #FIXME bug #9
-    #def test_6_u0_1imp_1occ(self):
-    #    """Tests for N=6 U=0 Hubbard model with single site impurities.
-    #    """
+    def test_6_u0_1imp_1occ(self):
+        """Tests for N=6 U=0 Hubbard model with single site impurities.
+        """
 
-    #    emb = edmet.EDMET(
-    #            testsystems.hubb_6_u0.rhf(),
-    #            solver='EBFCI',
-    #            max_boson_occ=1,
-    #    )
-    #    emb.site_fragmentation()
-    #    frag = emb.add_atomic_fragment(0)
-    #    frag.add_tsymmetric_fragments(tvecs=[6, 1, 1])
-    #    emb.kernel()
+        emb = edmet.EDMET(
+                testsystems.hubb_6_u0.rhf(),
+                solver='EBFCI',
+                solver_options={"max_boson_occ": 1},
+        )
 
-    #    known_values = {'e_tot': -8.0}
+        emb.symmetry.set_translations([6, 1, 1])
+        with emb.site_fragmentation() as f:
+            f.add_atomic_fragment([0])
+        emb.kernel()
 
-    #    self._test_energy(emb, known_values)
+        known_values = {'e_tot': -8.0}
 
-    #def test_6_u0_2imp_6occ(self):
-    #    """Tests for N=6 U=0 Hubbard model with double site impurities.
-    #    """
+        self._test_energy(emb, known_values)
 
-    #    emb = edmet.EDMET(
-    #            testsystems.hubb_6_u0.rhf(),
-    #            solver='EBFCI',
-    #            max_boson_occ=6,
-    #    )
-    #    emb.site_fragmentation()
-    #    frag = emb.add_atomic_fragment([0, 1])
-    #    frag.add_tsymmetric_fragments(tvecs=[3, 1, 1])
-    #    emb.kernel()
+    def test_6_u0_2imp_6occ(self):
+        """Tests for N=6 U=0 Hubbard model with double site impurities.
+        """
 
-    #    known_values = {'e_tot': -8.0}
+        emb = edmet.EDMET(
+                testsystems.hubb_6_u0.rhf(),
+                solver='EBFCI',
+                solver_options={"max_boson_occ": 6},
+        )
+        emb.symmetry.set_translations([3, 1, 1])
+        with emb.site_fragmentation() as f:
+            f.add_atomic_fragment([0, 1])
+        emb.kernel()
 
-    #    self._test_energy(emb, known_values)
+        known_values = {'e_tot': -8.0}
+
+        self._test_energy(emb, known_values)
 
     def test_10_u2_2imp_2occ(self):
         """Tests for N=10 U=2 Hubbard model with double site impurities.
@@ -62,54 +62,33 @@ class EDMET_Hubbard_Tests(TestCase):
                 oneshot=True,
                 make_dd_moments=False,
         )
+        emb.symmetry.set_translations([5, 1, 1])
         with emb.site_fragmentation() as f:
-            frag = f.add_atomic_fragment([0, 1])
-            frag.add_tsymmetric_fragments(tvecs=[5, 1, 1])
+            f.add_atomic_fragment([0, 1])
         emb.kernel()
 
         known_values = {'e_tot':-8.793485086132375}
 
         self._test_energy(emb, known_values)
 
-    # Suspended this test in favour of one with EBCCSD due to time constraints.
-    #def test_14_upoint4_2imp_4occ(self):
-    #    """Tests for N=14 U=0.4 Hubbard model with double site impurities.
-    #    """
+    def test_6x6_u0_1x1imp_2occ(self):
+        """Tests for 6x6 U=0 Hubbard model with single site impurities.
+        """
 
-    #    emb = edmet.EDMET(
-    #            testsystems.hubb_14_u0.rhf(),
-    #            solver='EBFCI',
-    #            solver_options={"max_boson_occ":3},
-    #            maxiter=30,
-    #            max_elec_err=1e-6
-    #    )
-    #    emb.site_fragmentation()
-    #    frag = emb.add_atomic_fragment([0, 1])
-    #    frag.add_tsymmetric_fragments(tvecs=[7, 1, 1])
-    #    emb.kernel()
+        emb = edmet.EDMET(
+                testsystems.hubb_6x6_u0_1x1imp.rhf(),
+                solver='EBFCI',
+                solver_options={"max_boson_occ": 2},
+        )
 
-    #    known_values = {'e_tot':-16.63125078900363}
+        emb.symmetry.set_translations([6, 6, 1])
+        with emb.site_fragmentation() as f:
+            f.add_atomic_fragment([0])
+        emb.kernel()
 
-    #    self._test_energy(emb, known_values)
+        known_values = {'e_tot': -56.0}
 
-    #FIXME bug #9
-    #def test_6x6_u0_1x1imp_2occ(self):
-    #    """Tests for 6x6 U=0 Hubbard model with single site impurities.
-    #    """
-
-    #    emb = edmet.EDMET(
-    #            testsystems.hubb_6x6_u0_1x1imp.rhf(),
-    #            solver='EBFCI',
-    #            max_boson_occ=2,
-    #    )
-    #    emb.site_fragmentation()
-    #    frag = emb.add_atomic_fragment([0])
-    #    frag.add_tsymmetric_fragments(tvecs=[6, 6, 1])
-    #    emb.kernel()
-
-    #    known_values = {'e_tot': -56.0}
-
-    #    self._test_energy(emb, known_values)
+        self._test_energy(emb, known_values)
 
     def test_6x6_u6_1x1imp_2occ(self):
         """Tests for 6x6 U=6 Hubbard model with single site impurities.
@@ -118,14 +97,14 @@ class EDMET_Hubbard_Tests(TestCase):
         emb = edmet.EDMET(
                 testsystems.hubb_6x6_u6_1x1imp.rhf(),
                 solver='EBFCI',
-                solver_options={"max_boson_occ":2},
+                solver_options={"max_boson_occ": 2},
                 bosonic_interaction="direct",
                 oneshot=True,
                 make_dd_moments=False,
         )
+        emb.symmetry.set_translations([6, 6, 1])
         with emb.site_fragmentation() as f:
-            frag = f.add_atomic_fragment([0])
-            frag.add_tsymmetric_fragments(tvecs=[6, 6, 1])
+            f.add_atomic_fragment([0])
         emb.kernel()
 
         known_values = {'e_tot':-49.255623407653644}

--- a/vayesta/tests/ewf/test_hubbard.py
+++ b/vayesta/tests/ewf/test_hubbard.py
@@ -55,6 +55,41 @@ class HubbardEWFTests(TestCase):
 
         self._test_energy(emb, known_values)
 
+    def test_10_u2_2imp_uhf(self):
+        """Tests for N=10 U=2 Hubbard model with double site impurities, with a uhf reference.
+        """
+
+        emb = ewf.EWF(
+                testsystems.hubb_10_u2.rhf(),
+                bno_threshold=1e-2,
+                solver_options={
+                    'conv_tol': self.CONV_TOL,
+                },
+               solver="FCI"
+        )
+        with emb.site_fragmentation() as f:
+            frag = f.add_atomic_fragment([0, 1])
+        frag.add_tsymmetric_fragments(tvecs=[5, 1, 1])
+        emb.kernel()
+
+
+        uemb = ewf.EWF(
+                testsystems.hubb_10_u2.uhf(),
+                bno_threshold=1e-2,
+                solver_options={
+                    'conv_tol': self.CONV_TOL,
+                },
+               solver="FCI"
+        )
+        with uemb.site_fragmentation() as f:
+            frag = f.add_atomic_fragment([0, 1])
+        frag.add_tsymmetric_fragments(tvecs=[5, 1, 1])
+        uemb.kernel()
+
+        known_values = {'e_tot': emb.e_tot}
+
+        self._test_energy(uemb, known_values)
+
     def test_6x6_u0_1x1imp(self):
         """Tests for 6x6 U=0 Hubbard model with single site impurities.
         """
@@ -114,6 +149,7 @@ class HubbardEWFTests(TestCase):
         known_values = {'e_tot': -84.3268698533661}
 
         self._test_energy(emb, known_values)
+
 
 
 if __name__ == '__main__':

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -301,7 +301,7 @@ class TestLattice:
 
     @cache
     def uhf(self):
-        uhf = latt.LatticeRHF(self.mol)
+        uhf = latt.LatticeUHF(self.mol)
         if self.with_df:
             uhf = uhf.density_fit()
         uhf.conv_tol = 1e-12


### PR DESCRIPTION
This allows UHF calculations to be run on the 1D Hubbard model, where previously this resulting in an error when generating the initial guess density.
This also updates various aspects of testing for Hubbard models while I was in there. Specifically
- Added test confirming unrestricted EWF calculation without spin-symmetry breaking on the 1D Hubbard model returns the same result as an equivalent restricted calculation.
- `TestLattice.uhf()` will now correctly return a `LatticeUHF` object.
- Reintroduced EDMET tests previously suspended due to #9, while also updating most tests in the same files to the new translational symmetry notation.