### PR TITLE
Remove initial guess for FCI test on dissociated, spin-symmetry-broken H2 test

### DIFF
--- a/vayesta/tests/ewf/test_h2.py
+++ b/vayesta/tests/ewf/test_h2.py
@@ -179,7 +179,10 @@ class Test_UFCI_dissoc(TestCase):
     @classmethod
     @cache
     def emb(cls, bno_threshold):
-        emb = vayesta.ewf.EWF(cls.mf, bath_options=dict(bathtype="dmet"), solver='FCI')
+        # TODO: fix this running with a CISD solver or initial guess.
+        #  This relates to https://github.com/BoothGroup/Vayesta/issues/83
+        emb = vayesta.ewf.EWF(cls.mf, bath_options=dict(bathtype="dmet"), solver='FCI',
+                              solver_options=dict(init_guess=None))
         emb.kernel()
         return emb
 


### PR DESCRIPTION
This fixes the test failures in #69 , as discussed in #83.
The underlying issues with pyscf and numpy are a bit gnarly, and in the interest of not holding up the original branch I've just removed the calculation of the CISD initial guess which is actually causing the errors and isn't what this actually wants to test. Catching all errors like this is going to be simplified if we have a more standardised approach to calculate our embedded integrals, such as in #66. An alternative tack could be forcing `incore_anyway` in these systems, which might be an OK halfway point.