### PR TITLE
Fix fci init_guess

### DIFF
--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -93,7 +93,7 @@ class FCI_Solver(ClusterSolver):
         if self.opts.init_guess in ["none", "None"]:
             return dict(ci0=None)
         if self.opts.init_guess == 'CISD':
-            self.log.info("Generating intitial guess from CISD.")
+            self.log.info("Generating initial guess from CISD.")
             return dict(ci0=self.get_cisd_init_guess())
         raise ValueError
 

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -90,9 +90,10 @@ class FCI_Solver(ClusterSolver):
         return 2*self.cluster.nocc_active
 
     def get_init_guess(self):
-        if self.opts.init_guess in ["none", "None"]:
+
+        if self.opts.init_guess in ["mf", "meanfield"]:
             return dict(ci0=None)
-        if self.opts.init_guess == 'CISD':
+        elif self.opts.init_guess == 'CISD':
             self.log.info("Generating initial guess from CISD.")
             return dict(ci0=self.get_cisd_init_guess())
         raise ValueError

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -96,7 +96,7 @@ class FCI_Solver(ClusterSolver):
         elif self.opts.init_guess == 'CISD':
             self.log.info("Generating initial guess from CISD.")
             return dict(ci0=self.get_cisd_init_guess())
-        raise ValueError
+        raise ValueError("Unknown initial guess: %s" % self.opts.init_guess)
 
     def get_cisd_init_guess(self):
         cisd = self.cisd_solver(self.mf, self.fragment, self.cluster)

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -90,7 +90,7 @@ class FCI_Solver(ClusterSolver):
         return 2*self.cluster.nocc_active
 
     def get_init_guess(self):
-        if self.opts.init_guess is None:
+        if self.opts.init_guess in ["none", "None"]:
             return dict(ci0=None)
         if self.opts.init_guess == 'CISD':
             self.log.info("Generating intitial guess from CISD.")

--- a/vayesta/tests/dmet/test_molecule.py
+++ b/vayesta/tests/dmet/test_molecule.py
@@ -5,7 +5,7 @@ from vayesta.tests.common import TestCase
 from vayesta.tests import testsystems
 
 
-FCI_SOLVER_OPTS = dict(davidson_only=False, init_guess=None)
+FCI_SOLVER_OPTS = dict(davidson_only=False, init_guess="mf")
 
 class MoleculeTest(TestCase):
     PLACES_ENERGY = 7

--- a/vayesta/tests/ewf/test_molecules.py
+++ b/vayesta/tests/ewf/test_molecules.py
@@ -192,7 +192,7 @@ class MoleculeTests(TestCase):
                 bath_options={'bathtype': 'dmet'},
                 solver='FCI',
                 solver_options={
-                    'init_guess': 'None',
+                    'init_guess': 'meanfield',
                     'conv_tol': 100,
                 }
         )

--- a/vayesta/tests/ewf/test_molecules.py
+++ b/vayesta/tests/ewf/test_molecules.py
@@ -183,6 +183,25 @@ class MoleculeTests(TestCase):
 
         self._test_energy(emb, known_values)
 
+    def test_h2o_FCI_noguess(self):
+        """Tests EWF for H2O cc-pvdz with FCI solver.
+        """
+
+        emb = ewf.EWF(
+                testsystems.water_ccpvdz.rhf(),
+                bath_options={'bathtype': 'dmet'},
+                solver='FCI',
+                solver_options={
+                    'init_guess': 'None',
+                    'conv_tol': 100,
+                }
+        )
+        emb.kernel()
+
+        known_values = {'e_tot': -76.02677312899381}
+
+        self._test_energy(emb, known_values)
+
     def test_h2o_TCCSD(self):
         """Tests EWF for H2O cc-pvdz with FCI solver.
         """


### PR DESCRIPTION
This fixes the control of initial guesses within the FCI solver, which I came across in the process of trying to fix #84.
I would suggest we merge this after #69 for simplicity; it's not anything high priority.
8502952ee77304ba9141ead8369b36af03d497c9 added the function
```
    def get_init_guess(self):
        if self.opts.init_guess is None:
            return dict(ci0=None)
        if self.opts.init_guess == 'CISD':
            self.log.info("Generating intitial guess from CISD.")
            return dict(ci0=self.get_cisd_init_guess())
        raise ValueError
```
to control the generation of initial guesses for FCI wavefunctions. This seems to have intended passing `solver_opts={"init_guess":None}` to result in an initial guess of the HF determinant, rather than the CISD wavefunction. However, due to inheritance within the code interpreting `None` as the user not passing anything in this actually results in `init_guess="default"(="CISD")` by the time it gets into this function.

As a fix I've just changed this option to instead require "None" or "none". I've also added a test checking the energy of a prematurely terminated calculation correctly starting from the HF initial guess, which is hopefully OK so long as the first step of a davidson is deterministic (which I wouldn't be certain of, but seems OK in initial testing and we'll find out from the CI...).