### PR TITLE
Fix dissociated H2 test.

### DIFF
--- a/vayesta/tests/ewf/test_h2.py
+++ b/vayesta/tests/ewf/test_h2.py
@@ -167,8 +167,9 @@ class Test_UFCI_dissoc(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.mf = testsystems.h2_sto3g_dissoc_df.uhf_stable()
-        cls.fci = testsystems.h2_sto3g_dissoc_df.ufci()
+        # TODO ensure this tests works if density fitting is used.
+        cls.mf = testsystems.h2_sto3g_dissoc.uhf_stable()
+        cls.fci = testsystems.h2_sto3g_dissoc.ufci()
 
     @classmethod
     def tearDownClass(cls):

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -76,7 +76,12 @@ class TestMolecule:
     def uhf_stable(self):
         # Get uhf solution, and copy to avoid changing attributes.
         uhf = copy.copy(self.uhf())
-        # Repeat this procedure a few times; it should converge pretty rapidly, but we don't want to get stuck in an
+        # Follow procedure from pyscf/examples/scf/32-break_spin_symm.py to ensure symmetry breaking in initial guess.
+        # Use standard calculation as initial guess.
+        dm0 = uhf.make_rdm1()
+        uhf.kernel(dm0=(dm0[0], np.zeros_like(dm0[1])))
+
+        # Repeat this procedure a few times; it should converge rapidly, but we don't want to get stuck in an
         # infinite loop if it doesn't.
         for i in range(5):
             # Check stability of current solution.
@@ -334,7 +339,7 @@ class TestLattice:
 
 h2_dz = TestMolecule("H 0 0 0; H 0 0 0.74", basis="cc-pvdz")
 h2anion_dz = TestMolecule("H 0 0 0; H 0 0 0.74", basis="cc-pvdz", charge=-1, spin=1)
-h2_sto3g_dissoc_df = TestMolecule("H 0 0 0; H 0 0 10.0", basis="sto3g", auxbasis=True)
+h2_sto3g_dissoc = TestMolecule("H 0 0 0; H 0 0 10.0", basis="sto3g")
 
 h6_sto6g = TestMolecule(
         atom=["H %f %f %f" % xyz for xyz in pyscf.tools.ring.make(6, 1.0)],


### PR DESCRIPTION
This fixes the test failures on #69, as discussed in #83, by changing the test to use dense ERIs rather than density fitting. Breaking spin symmetry here required a more explicitly symmetry-broken initial guess than with density fitting, so I've added the suggested approach to break symmetries from `pyscf/examples/scf/32-break_spin_symm.py` into `TestMolecule.uhf_stable`.

This doesn't fix using density fitting in this system- that's proved more difficult (see #84, which I'm going to close now), but given it's an edge case this seems acceptable for now. I would say we could just add a warning/error if a cluster has no excitations in a spin channel and is using density fitting, but this is going to come up again if we're running large Hubbard models.

For now this passes the tests in the only place I can currently produce the original error (thanks Abhi!) so hopefully removes a blocker to #69 merging.