### PR TITLE
UFCI different norbs in spin channels

### DIFF
--- a/vayesta/core/qemb/scrcoulomb.py
+++ b/vayesta/core/qemb/scrcoulomb.py
@@ -79,7 +79,7 @@ def build_screened_eris(emb, fragments=None, cderi_ov=None, calc_e=True, npoints
 
     # Then construct the RPA coupling matrix A-B, given by the diagonal matrix of energy differences.
     no = np.array(sum(emb.mf.mo_occ.T > 0))
-    norb = emb.mo_coeff.shape[1]
+    norb = np.array(emb.mo_coeff).shape[1]
     nv = norb - no
 
     def get_eps_singlespin(no_, nv_, mo_energy):

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -5,6 +5,7 @@ import pyscf.fci
 import pyscf.fci.addons
 
 from vayesta.core.types import FCI_WaveFunction
+from vayesta.core.types.wf.fci import UFCI_WaveFunction_w_dummy
 from vayesta.core.util import log_time
 from vayesta.solver.cisd import RCISD_Solver, UCISD_Solver
 from vayesta.solver.solver import ClusterSolver, UClusterSolver
@@ -87,3 +88,28 @@ class UFCI_Solver(UClusterSolver, FCI_Solver):
 
     def get_solver_class(self):
         return pyscf.fci.direct_uhf.FCISolver
+
+    def kernel(self, ci=None):
+
+        na, nb = self.hamil.ncas
+        if na == nb:
+            super().kernel(ci)
+            return
+        # Only consider this functionality when it's needed.
+        if ci is None and self.opts.init_guess == "CISD":
+            cisd = self.cisd_solver(self.hamil)
+            cisd.kernel()
+            ci = cisd.wf.as_fci().ci
+            if self.opts.init_guess_noise:
+                ci += self.opts.init_guess_noise * np.random.random(ci.shape)
+
+        mf, orbs_to_freeze = self.hamil.to_pyscf_mf(allow_dummy_orbs=True, allow_df=False)
+
+        heff = mf.get_hcore()
+        eris = mf._eri
+
+        with log_time(self.log.timing, "Time for FCI: %s"):
+            e_fci, self.civec = self.solver.kernel(heff, eris, mf.mol.nao, self.hamil.nelec, ci0=ci)
+        self.converged = self.solver.converged
+        self.log.critical("%d %d", *self.hamil.mo.norb)
+        self.wf = UFCI_WaveFunction_w_dummy(self.hamil.mo, self.civec, dummy_orbs=orbs_to_freeze)

--- a/vayesta/solver/fci.py
+++ b/vayesta/solver/fci.py
@@ -111,5 +111,4 @@ class UFCI_Solver(UClusterSolver, FCI_Solver):
         with log_time(self.log.timing, "Time for FCI: %s"):
             e_fci, self.civec = self.solver.kernel(heff, eris, mf.mol.nao, self.hamil.nelec, ci0=ci)
         self.converged = self.solver.converged
-        self.log.critical("%d %d", *self.hamil.mo.norb)
         self.wf = UFCI_WaveFunction_w_dummy(self.hamil.mo, self.civec, dummy_orbs=orbs_to_freeze)

--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -256,6 +256,7 @@ class RClusterHamiltonian:
             orbs_to_freeze = None
             dummy_energy = 0.0
         else:
+            self.log.info("Using %d dummy orbitals to pad local Hamiltonian. %d!=%d", nmo - nsm, *self.ncas)
             # Note that this branch is actually UHF-exclusive.
             padchannel = self.ncas.index(nsm)
             orbs_to_freeze = [[], []]
@@ -404,7 +405,7 @@ class RClusterHamiltonian:
         na, nb = self.ncas
         if na != nb:
             raise NotImplementedError("Active spaces with different number of alpha and beta orbitals are not yet "
-                                      "supported with this configuration. %s", message)
+                                      "supported with this configuration. %s" % message)
 
     def with_new_cluster(self, cluster):
         return self.__class__(self._fragment, self.orig_mf, self.log, cluster, **self.opts.asdict())

--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -256,7 +256,7 @@ class RClusterHamiltonian:
             orbs_to_freeze = None
             dummy_energy = 0.0
         else:
-            self.log.info("Using %d dummy orbitals to pad local Hamiltonian. %d!=%d", nmo - nsm, *self.ncas)
+            self.log.info("Using %d dummy orbital(s) to pad local Hamiltonian.", nmo - nsm)
             # Note that this branch is actually UHF-exclusive.
             padchannel = self.ncas.index(nsm)
             orbs_to_freeze = [[], []]

--- a/vayesta/tests/core/wf/test_wf.py
+++ b/vayesta/tests/core/wf/test_wf.py
@@ -13,6 +13,59 @@ from vayesta.core.util import *
 from vayesta.tests.common import TestCase
 from vayesta.tests import testsystems
 
+
+
+
+class Test_UFCI_wf_w_dummy(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mf = testsystems.heli_631g.uhf()
+        cls.ufci = testsystems.heli_631g.ufci()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mf
+        del cls.ufci
+
+    def get_ufci_ref(self):
+        return self.ufci.e_tot
+
+    def test_ufci_w_dummy_atomic_fragmentation(self):
+        emb = vayesta.ewf.EWF(self.mf)
+
+        with emb.iao_fragmentation() as f:
+            fci_frags = f.add_all_atomic_fragments(solver='FCI',
+         bath_options=dict(bathtype='full'), store_wf_type='CCSDTQ', auxiliary=True)
+            ccsd_frag = f.add_full_system(solver='CCSD', bath_options=dict(bathtype='full'))
+        ccsd_frag.add_external_corrections(fci_frags, correction_type='external', projectors=1, low_level_coul=True)
+        emb.kernel()
+
+        self.assertAlmostEqual(emb.e_tot, self.get_ufci_ref())
+
+    def test_ufci_w_dummy_full_system_fragment(self):
+        emb = vayesta.ewf.EWF(self.mf)
+        fci_frags=[]
+        with emb.iao_fragmentation() as f:
+            fci_frags.append(f.add_full_system(solver='FCI',
+         bath_options=dict(bathtype='full'), store_wf_type='CCSDTQ', auxiliary=True))
+            ccsd_frag = f.add_full_system(solver='CCSD', bath_options=dict(bathtype='full'))
+        ccsd_frag.add_external_corrections(fci_frags, correction_type='external', projectors=1, low_level_coul=True)
+        emb.kernel()
+
+        self.assertAlmostEqual(emb.e_tot, self.get_ufci_ref())
+
+    def test_ufci_w_dummy_regression_full_system_fragment(self):
+        emb = vayesta.ewf.EWF(self.mf)
+        fci_frags=[]
+        with emb.iao_fragmentation() as f:
+            fci_frags.append(f.add_full_system(solver='FCI',
+                bath_options=dict(bathtype='dmet'), store_wf_type='CCSDTQ', auxiliary=True))
+            ccsd_frag = f.add_full_system(solver='CCSD', bath_options=dict(bathtype='full'))
+        ccsd_frag.add_external_corrections(fci_frags, correction_type='external', projectors=1, low_level_coul=True)
+        emb.kernel()
+
+        self.assertAlmostEqual(emb.e_tot, -10.290621999634174)
+
 class Test_DM(TestCase):
 
     solver = 'CCSD'

--- a/vayesta/tests/core/wf/test_wf.py
+++ b/vayesta/tests/core/wf/test_wf.py
@@ -59,7 +59,8 @@ class Test_UFCI_wf_w_dummy(TestCase):
         fci_frags=[]
         with emb.iao_fragmentation() as f:
             fci_frags.append(f.add_full_system(solver='FCI',
-                bath_options=dict(bathtype='dmet'), store_wf_type='CCSDTQ', auxiliary=True))
+                bath_options=dict(bathtype='dmet'), store_wf_type='CCSDTQ', auxiliary=True,
+                                               solver_options={"init_guess":"mf"}))
             ccsd_frag = f.add_full_system(solver='CCSD', bath_options=dict(bathtype='full'))
         ccsd_frag.add_external_corrections(fci_frags, correction_type='external', projectors=1, low_level_coul=True)
         emb.kernel()

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -373,6 +373,7 @@ h2_ccpvdz_df = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0", basis="cc-pvdz", auxbas
 h3_ccpvdz = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0", basis="cc-pvdz", spin=1)
 h3_ccpvdz_df = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0", basis="cc-pvdz", auxbasis="cc-pvdz-jkfit", spin=1)
 
+heli_631g = TestMolecule(atom="He 0 0 0; Li 0 0 2.0", basis='6-31G', spin=1)
 h6_dz = TestMolecule(atom=molecules.ring('H', 6, 1.0), basis='cc-pVDZ')
 
 atoms = 'N 0 0 -0.75; N 0 0 0.75'


### PR DESCRIPTION
This updates the UFCI solver to support clusters with different numbers of orbitals within the alpha and beta spin channels. This makes use of the dummy orbital construction contained within #92. However, implementation was complicated by the fact that neither pyscf's FCI and CASCI functionality support having different numbers of active orbitals in different spin channels, and that we use the associated FCI functions as a backend when calculating wavefunction properties within `UFCI_WaveFunction`.

To get around this, this PR implements an object `UFCI_WaveFunction_w_dummy` which represents a UFCI wavefunction with differing numbers of orbitals in the different spin channels via the wavefunction padded with dummy orbitals. These dummy orbitals are traced out of any expectation values before returning them, allowing us to avoid implementing a CI solver for this specific case. One this is done implementation of the actual solver is straightforward.

I think this is a reasonable, if slightly odd, approach but I thought it worth discussing separately to #92 for the sake of making sure others agree.

~~(Test failures are due to final commits of #92 not yet being incorporated into this branch; once that PR is stable I'll update this branch)~~