### PR TITLE
Fix SCMF/python 3.11 support

### DIFF
--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -1627,9 +1627,9 @@ class Embedding:
     def pdmet_scmf(self, *args, **kwargs):
         """Decorator for p-DMET."""
         self.with_scmf = PDMET(self, *args, **kwargs)
-        self.kernel = self.with_scmf.kernel.__get__(self)
+        self.kernel = self.with_scmf.kernel
 
     def brueckner_scmf(self, *args, **kwargs):
         """Decorator for Brueckner-DMET."""
         self.with_scmf = Brueckner(self, *args, **kwargs)
-        self.kernel = self.with_scmf.kernel.__get__(self)
+        self.kernel = self.with_scmf.kernel

--- a/vayesta/tests/core/scmf/test_scmf.py
+++ b/vayesta/tests/core/scmf/test_scmf.py
@@ -31,13 +31,12 @@ class SCMF_Test(TestCase):
 
     def test_pdmet(self):
         """Test p-DMET."""
-        return
         emb0 = self.emb()
         emb = self.emb('pdmet')
         self.assertAllclose(emb.with_scmf.e_tot_oneshot, emb0.e_tot)
         self.assertAllclose(emb.with_scmf.e_tot_oneshot, -1.1419060823155505)
         self.assertTrue(emb.with_scmf.converged)
-        self.assertAllclose(emb.with_scmf.e_tot, -1.1417159316065975)
+        self.assertAllclose(emb.with_scmf.e_tot, -1.1417348230969397)
 
     def test_brueckner(self):
         """Test Brueckner DMET."""


### PR DESCRIPTION
This implements the changes suggested in #91 to avoid test failures when running python 3.11, while also reactivating the pDMET test and updating it so it passes (in my running). This doesn't update any configuration options etc as I think we can do that all in one place- which is #97 or a follow-up to it.

This is entirely self-contained and shouldn't affect any outstanding PRs.