### PR TITLE
Added informative error message when encountering pyscf space_group_symmetry bug.

### DIFF
--- a/examples/ewf/solids/01-simple-sym.py
+++ b/examples/ewf/solids/01-simple-sym.py
@@ -6,15 +6,16 @@ import vayesta
 import vayesta.ewf
 
 
-# For an equivalent calculation enforcing symmetries, see examples/ewf/solids/01-simple-sym.py
 cell = pyscf.pbc.gto.Cell()
 cell.atom = ['He 0.0 0.0 0.0']
 cell.a = 1.4 * np.eye(3)
 cell.basis = 'def2-svp'
 cell.output = 'pyscf.out'
+cell.space_group_symmetry = True
+cell.symmorphic = True
 cell.build()
-
-kpts = cell.make_kpts([2,2,2])
+# Enforce all symmetries in kpoint generation.
+kpts = cell.make_kpts([2,2,2], space_group_symmetry=True, time_reversal_symmetry=True, symmorphic=True)
 
 # Hartree-Fock with k-points
 mf = pyscf.pbc.scf.KRHF(cell, kpts)
@@ -24,8 +25,13 @@ mf.kernel()
 # Embedded calculation will automatically unfold the k-point sampled mean-field
 emb = vayesta.ewf.EWF(mf, bath_options=dict(threshold=1e-4))
 # If calling the kernel without initializiation fragmentation and fragments,
-# IAO fragmentation and atomic fragments are used automatically
+# IAO fragmentation and atomic fragments are used automatically.
 emb.kernel()
+
+# Some versions of pyscf may encounter an error when generating IAOs with space_group_symmetry=True.
+# To avoid this, turn off space group symmetry before generating IAOs, as below:
+# emb.mf.mol.space_group_symmetry = False
+# emb.kernel()
 
 print("E(HF)=        %+16.8f Ha" % (mf.e_tot))
 print("E(Emb. CCSD)= %+16.8f Ha" % (emb.e_tot))

--- a/vayesta/core/fragmentation/iao.py
+++ b/vayesta/core/fragmentation/iao.py
@@ -40,7 +40,19 @@ class IAO_Fragmentation(Fragmentation):
         else:
             self.log.debug("IAO:  computational basis= %s  minimal reference basis= %s", self.mol.basis, minao)
         self.minao = minao
-        self.refmol = pyscf.lo.iao.reference_mol(self.mol, minao=self.minao)
+        try:
+            self.refmol = pyscf.lo.iao.reference_mol(self.mol, minao=self.minao)
+        except IndexError as e:
+            if hasattr(self.mol, "space_group_symmetry"):
+                if self.mol.space_group_symmetry:
+                    self.log.error("Could not find IAOs when using space group symmetry.")
+                    self.log.error("This is a known issue with some PySCF versions.")
+                    self.log.error(
+                        "Please set `emb.mf.mol.space_group_symmetry=False` when initialising the fragmentation (it can be turned back on afterwards).")
+                    raise ValueError(
+                        "Could not find IAOs when using space group symmetry. Please set `emb.mf.mol.space_group_symmetry=False`.")
+            raise e
+
 
     @property
     def n_iao(self):


### PR DESCRIPTION
This relates to the errors mentioned in #106.

This returns a more informative error message when encountering a bug with generating IAOs in pyscf with space group symmetry enabled. This should only be present in a small number of pyscf versions, so requiring the user to update their input rather than trying to handle it internally seems a reasonable. The fix is to just disable space group symmetry for the mean-field calculation when initialising the IAO fragmentation; it can be turned back on afterwards if desired.
