### PR TITLE
Corrfunc orb filtering

### DIFF
--- a/vayesta/core/qemb/corrfunc.py
+++ b/vayesta/core/qemb/corrfunc.py
@@ -42,7 +42,8 @@ def get_corrfunc_mf(emb, kind, dm1=None, atoms=None, projection='sao'):
     return corr
 
 
-def get_corrfunc(emb, kind, dm1=None, dm2=None, atoms=None, projection='sao', dm2_with_dm1=None, use_symmetry=True):
+def get_corrfunc(emb, kind, dm1=None, dm2=None, atoms=None, projection='sao', dm2_with_dm1=None, use_symmetry=True,
+                 orbital_filter=None):
     """Get expectation values <P(A) S_z P(B) S_z>, where P(X) are projectors onto atoms X.
 
     TODO: MPI
@@ -80,7 +81,7 @@ def get_corrfunc(emb, kind, dm1=None, dm2=None, atoms=None, projection='sao', dm
             norm = einsum('iikk->', dm2)
             ne2 = emb.mol.nelectron*(emb.mol.nelectron-1)
             dm2_with_dm1 = (norm > ne2/2)
-    atoms1, atoms2, proj = emb._get_atom_projectors(atoms, projection)
+    atoms1, atoms2, proj = emb._get_atom_projectors(atoms, projection, orbital_filter=orbital_filter)
     corr = np.zeros((len(atoms1), len(atoms2)))
 
     # 1-DM contribution:
@@ -164,7 +165,7 @@ def get_corrfunc(emb, kind, dm1=None, dm2=None, atoms=None, projection='sao', dm
     return corr
 
 def get_corrfunc_unrestricted(emb, kind, dm1=None, dm2=None, atoms=None, projection='sao', dm2_with_dm1=None,
-                              use_symmetry=True):
+                              use_symmetry=True, orbital_filter=None):
     """Get expectation values <P(A) S_z P(B) S_z>, where P(X) are projectors onto atoms X.
 
     TODO: MPI
@@ -203,7 +204,7 @@ def get_corrfunc_unrestricted(emb, kind, dm1=None, dm2=None, atoms=None, project
             norm = einsum('iikk->', dm2[0]) + 2*einsum('iikk->', dm2[1]) + einsum('iikk->', dm2[2])
             ne2 = emb.mol.nelectron*(emb.mol.nelectron-1)
             dm2_with_dm1 = (norm > ne2/2)
-    atoms1, atoms2, proj = emb._get_atom_projectors(atoms, projection)
+    atoms1, atoms2, proj = emb._get_atom_projectors(atoms, projection, orbital_filter=orbital_filter)
     corr = np.zeros((len(atoms1), len(atoms2)))
 
     # 1-DM contribution:

--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -1316,6 +1316,9 @@ class Embedding:
             frag = SAO_Fragmentation(self)
         elif projection.replace('+', '').replace('/', '') == 'iaopao':
             frag = IAOPAO_Fragmentation(self)
+        elif projection == 'iao':
+            self.log.warning("IAO projection is not recommended for population analysis. Use SAO or IAO+PAO instead.")
+            frag = IAO_Fragmentation(self)
         else:
             raise ValueError("Invalid projection: %s" % projection)
         frag.kernel()

--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -1318,7 +1318,7 @@ class Embedding:
             frag = IAOPAO_Fragmentation(self)
         elif projection == 'iao':
             frag = IAO_Fragmentation(self)
-            self.log.warning("IAO projection is not recommended for population analysis! Use IAO+SAO instead.")
+            self.log.warning("IAO projection is not recommended for population analysis! Use IAO+PAO instead.")
         else:
             raise ValueError("Invalid projection: %s" % projection)
         frag.kernel()

--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -1328,7 +1328,12 @@ class Embedding:
         for atom in sorted(set(atoms1).union(atoms2)):
             name, indices = frag.get_atomic_fragment_indices(atom, orbital_filter=orbital_filter)
             c_atom = frag.get_frag_coeff(indices)
-            if c_atom.shape[1] == 0 and orbital_filter is not None:
+            if isinstance(c_atom, tuple):
+                no_orbs = c_atom[0].shape[1] == 0 and c_atom[1].shape[1] == 0
+            else:
+                no_orbs = c_atom.shape[1] == 0
+
+            if no_orbs and orbital_filter is not None:
                 self.log.error("No orbitals found for atom %d when filtered!" % atom)
                 raise ValueError("No orbitals found for atom %d when filtered" % atom)
             r = spinalg.dot(cs, c_atom)


### PR DESCRIPTION
This adds the options to generate correlation functions using a IAO fragmentation and for specific target orbitals within the corrfunc functionality of the embedding methods. This allows correlation functions to be calculated in specific local orbital spaces on each atom, rather than the full local hilbert space.