### PR TITLE
Add logo.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ prune vayesta/libs/build
 recursive-include vayesta *.dat
 recursive-include vayesta/misc/gmtkn55 *
 include vayesta/libs/*.so
+include vayesta/logo.txt
 
 # MacOS dynamic libraries
 include vayesta/libs/*.dylib


### PR DESCRIPTION
The `logo.txt` didn't appear in `MANIFEST.in`, so it wasn't part of the package. Somehow this is only an issue when a test failed on the scheduled CI