### PR TITLE
Force SciPy <= 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.19.0",
-    "scipy>=1.1.0",
+    "scipy>=1.1.0,<=1.10.0",
     "h5py>=2.7",
     "cvxpy>=1.1",
     "pyscf @ git+https://github.com/pyscf/pyscf@master",


### PR DESCRIPTION
This PR temporarily freezes the SciPy version, as 1.11.0 seems to break both cvxpy and PySCF.