### PR TITLE
Changes ebcc dependency to pip wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,13 +66,13 @@ dyson = [
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
 ]
 ebcc = [
-    "ebcc @ git+https://github.com/BoothGroup/ebcc@master",
+    "ebcc"
 ]
 dev = [
     "cvxpy>=1.1",
     "mpi4py>=3.0.0",
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
-    "ebcc @ git+https://github.com/BoothGroup/ebcc@master",
+    "ebcc",
     "pytest",
     "pytest-cov",
 ]


### PR DESCRIPTION
`ebcc` is now available as a `pip` wheel, this PR changes the dependency to reflect that.