### PR TITLE
CCSDt' interface (and general EBCC interface updates)

### DIFF
--- a/examples/ewf/molecules/26-ebCC-solvers.py
+++ b/examples/ewf/molecules/26-ebCC-solvers.py
@@ -1,0 +1,52 @@
+import pyscf
+import pyscf.gto
+import pyscf.scf
+import pyscf.mcscf
+
+import vayesta
+import vayesta.ewf
+
+mol = pyscf.gto.Mole()
+mol.atom = ['N 0 0 0', 'N 0 0 2']
+mol.basis = 'aug-cc-pvdz'
+mol.output = 'pyscf.out'
+mol.build()
+
+# Hartree-Fock
+mf = pyscf.scf.RHF(mol)
+mf.kernel()
+
+# Reference CASCI
+casci = pyscf.mcscf.CASCI(mf, 8, 10)
+casci.kernel()
+
+# Reference CASSCF
+casscf = pyscf.mcscf.CASSCF(mf, 8, 10)
+casscf.kernel()
+
+def get_emb_result(ansatz, bathtype='full'):
+    # Uses fastest available solver for given ansatz; PySCF if available, otherwise ebCC
+    emb = vayesta.ewf.EWF(mf, solver=ansatz, bath_options=dict(bathtype=bathtype),
+                          solver_options=dict(solve_lambda=False))
+    # Both these alternative specifications will always use an ebCC solver.
+    #emb = vayesta.ewf.EWF(mf, solver=f'EB{ansatz}', bath_options=dict(bathtype=bathtype),
+    #                      solver_options=dict(solve_lambda=False))
+    #emb = vayesta.ewf.EWF(mf, solver='EBCC', bath_options=dict(bathtype=bathtype),
+    #                      solver_options=dict(solve_lambda=False, ansatz=ansatz))
+
+    with emb.iao_fragmentation() as f:
+        with f.rotational_symmetry(2, "y", center=(0, 0, 1)):
+            f.add_atomic_fragment(0)
+    emb.kernel()
+    return emb.e_tot
+
+e_ccsd = get_emb_result('CCSD', 'full')
+e_ccsdt = get_emb_result('CCSDT', 'dmet')
+e_ccsdtprime = get_emb_result("CCSDt'", 'full')
+
+print("E(HF)=                                           %+16.8f Ha" % mf.e_tot)
+print("E(CASCI)=                                        %+16.8f Ha" % casci.e_tot)
+print("E(CASSCF)=                                       %+16.8f Ha" % casscf.e_tot)
+print("E(CCSD, complete)=                               %+16.8f Ha" % e_ccsd)
+print("E(emb. CCSDT, DMET CAS)=                         %+16.8f Ha" % e_ccsdt)
+print("E(emb. CCSDt', complete+DMET active space)=      %+16.8f Ha" % e_ccsdtprime)

--- a/examples/ewf/molecules/26-ebcc-solvers.py
+++ b/examples/ewf/molecules/26-ebcc-solvers.py
@@ -25,13 +25,14 @@ casscf = pyscf.mcscf.CASSCF(mf, 8, 10)
 casscf.kernel()
 
 def get_emb_result(ansatz, bathtype='full'):
-    # Uses fastest available solver for given ansatz; PySCF if available, otherwise ebCC
+    # Uses fastest available solver for given ansatz; PySCF if available, otherwise ebcc.
     emb = vayesta.ewf.EWF(mf, solver=ansatz, bath_options=dict(bathtype=bathtype),
                           solver_options=dict(solve_lambda=False))
-    # Both these alternative specifications will always use an ebCC solver.
+    # Both these alternative specifications will always use an ebcc solver.
+    # Note that the capitalization of the solver name other than the ansatz is arbitrary.
     #emb = vayesta.ewf.EWF(mf, solver=f'EB{ansatz}', bath_options=dict(bathtype=bathtype),
     #                      solver_options=dict(solve_lambda=False))
-    #emb = vayesta.ewf.EWF(mf, solver='EBCC', bath_options=dict(bathtype=bathtype),
+    #emb = vayesta.ewf.EWF(mf, solver='ebcc', bath_options=dict(bathtype=bathtype),
     #                      solver_options=dict(solve_lambda=False, ansatz=ansatz))
 
     with emb.iao_fragmentation() as f:

--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -105,7 +105,7 @@ class Options(OptionsBase):
             # EBFCI/EBCCSD
             max_boson_occ=2,
             # EBCC
-            ansatz=None,
+            ansatz=None, store_as_ccsd=None,
             # Dump
             dumpfile='clusters.h5',
             # MP2

--- a/vayesta/core/types/wf/ccsd.py
+++ b/vayesta/core/types/wf/ccsd.py
@@ -202,9 +202,9 @@ class RCCSD_WaveFunction(wf_types.WaveFunction):
         wf.t1 = transform_c1(wf.t1, to, tv)
         wf.t2 = transform_c2(wf.t2, to, tv)
         if wf.l1 is not None:
-            wf.l1 = transform_uc1(wf.l1, to, tv)
+            wf.l1 = transform_c1(wf.l1, to, tv)
         if wf.l2 is not None:
-            wf.l2 = transform_uc2(wf.l2, to, tv)
+            wf.l2 = transform_c2(wf.l2, to, tv)
         return wf
 
 class UCCSD_WaveFunction(RCCSD_WaveFunction):

--- a/vayesta/core/types/wf/ccsd.py
+++ b/vayesta/core/types/wf/ccsd.py
@@ -13,6 +13,7 @@ from vayesta.core.types.wf.project import (project_c1, project_c2, project_uc1, 
 from vayesta.core.helper import pack_arrays, unpack_arrays
 from scipy.linalg import block_diag
 
+
 def CCSD_WaveFunction(mo, t1, t2, **kwargs):
     if mo.nspin == 1:
         cls = RCCSD_WaveFunction
@@ -186,7 +187,6 @@ class RCCSD_WaveFunction(wf_types.WaveFunction):
             raise ValueError("Provided rotation mixes occupied and virtual orbitals.")
         return self.rotate_ov(to, tv, inplace=inplace)
 
-
     def rotate_ov(self, to, tv, inplace=False):
         """Rotate wavefunction representation to another basis.
         Only rotations which don't mix occupied and virtual orbitals are supported.
@@ -206,6 +206,7 @@ class RCCSD_WaveFunction(wf_types.WaveFunction):
         if wf.l2 is not None:
             wf.l2 = transform_c2(wf.l2, to, tv)
         return wf
+
 
 class UCCSD_WaveFunction(RCCSD_WaveFunction):
 
@@ -356,7 +357,6 @@ class UCCSD_WaveFunction(RCCSD_WaveFunction):
 
         return self.rotate_ov((toa, tob), (tva, tvb), inplace=inplace)
 
-
     def rotate_ov(self, to, tv, inplace=False):
         """Rotate wavefunction representation to another basis.
         Only rotations which don't mix occupied and virtual orbitals are supported.
@@ -382,7 +382,6 @@ class UCCSD_WaveFunction(RCCSD_WaveFunction):
         if wf.l2 is not None:
             wf.l2 = transform_uc2(wf.l2, to, tv)
         return wf
-
 
     #def pack(self, dtype=float):
     #    """Pack into a single array of data type `dtype`.

--- a/vayesta/core/types/wf/ccsd.py
+++ b/vayesta/core/types/wf/ccsd.py
@@ -5,13 +5,13 @@ from vayesta.core.vpyscf import uccsd_rdm
 # import pyscf
 # import pyscf.cc
 from vayesta.core import spinalg
-from vayesta.core.util import NotCalculatedError, Object, callif, einsum
+from vayesta.core.util import NotCalculatedError, Object, callif, einsum, dot
 from vayesta.core.types import wf as wf_types
 from vayesta.core.types.orbitals import SpatialOrbitals
 from vayesta.core.types.wf.project import (project_c1, project_c2, project_uc1, project_uc2, symmetrize_c2,
-                                           symmetrize_uc2)
+                                           symmetrize_uc2, transform_c1, transform_c2, transform_uc1, transform_uc2)
 from vayesta.core.helper import pack_arrays, unpack_arrays
-
+from scipy.linalg import block_diag
 
 def CCSD_WaveFunction(mo, t1, t2, **kwargs):
     if mo.nspin == 1:
@@ -170,6 +170,21 @@ class RCCSD_WaveFunction(wf_types.WaveFunction):
     def as_fci(self):
         raise NotImplementedError
 
+    def rotate(self, to, tv, inplace=False):
+        """Rotate wavefunction representation to another basis.
+        Only rotations which don't mix occupied and virtual orbitals are supported.
+
+        Parameters
+        ----------
+        to : new occupied orbital coefficients in terms of current ones.
+        tv : new virtual orbital coefficients in terms of current ones.
+        inplace : Whether to transform in-place or return a new object.
+        """
+        wf = self if inplace else self.copy()
+        wf.mo.basis_transform(lambda c: dot(c, block_diag(to, tv)), inplace=True)
+        wf.t1 = transform_c1(wf.t1, to, tv)
+        wf.t2 = transform_c2(wf.t2, to, tv)
+        return wf
 
 class UCCSD_WaveFunction(RCCSD_WaveFunction):
 
@@ -295,6 +310,29 @@ class UCCSD_WaveFunction(RCCSD_WaveFunction):
             self.l1 = spinalg.multiply(self.l1, len(self.l1)*[factor])
         if self.l2 is not None:
             self.l2 = spinalg.multiply(self.l2, len(self.l2)*[factor])
+
+    def rotate(self, to, tv, inplace=False):
+        """Rotate wavefunction representation to another basis.
+        Only rotations which don't mix occupied and virtual orbitals are supported.
+
+        Parameters
+        ----------
+        to : new occupied orbital coefficients in terms of current ones.
+        tv : new virtual orbital coefficients in terms of current ones.
+        inplace : Whether to transform in-place or return a new object.
+        """
+        wf = self if inplace else self.copy()
+        if isinstance(to, np.ndarray) and len(to) == 2:
+            assert( isinstance(tv, np.ndarray) and len(tv) == 2)
+            trafo = lambda c: dot(c, block_diag(to, tv))
+        else:
+            trafo = [lambda c: dot(c, x) for x in (block_diag(to[0], tv[0]), block_diag(to[1], tv[1]))]
+
+        wf.mo.basis_transform(trafo, inplace=True)
+        wf.t1 = transform_uc1(wf.t1, to, tv)
+        wf.t2 = transform_uc2(wf.t2, to, tv)
+        return wf
+
 
     #def pack(self, dtype=float):
     #    """Pack into a single array of data type `dtype`.

--- a/vayesta/core/types/wf/ccsd.py
+++ b/vayesta/core/types/wf/ccsd.py
@@ -201,6 +201,10 @@ class RCCSD_WaveFunction(wf_types.WaveFunction):
         wf.mo.basis_transform(lambda c: dot(c, block_diag(to, tv)), inplace=True)
         wf.t1 = transform_c1(wf.t1, to, tv)
         wf.t2 = transform_c2(wf.t2, to, tv)
+        if wf.l1 is not None:
+            wf.l1 = transform_uc1(wf.l1, to, tv)
+        if wf.l2 is not None:
+            wf.l2 = transform_uc2(wf.l2, to, tv)
         return wf
 
 class UCCSD_WaveFunction(RCCSD_WaveFunction):
@@ -373,6 +377,10 @@ class UCCSD_WaveFunction(RCCSD_WaveFunction):
         wf.mo.basis_transform(trafo, inplace=True)
         wf.t1 = transform_uc1(wf.t1, to, tv)
         wf.t2 = transform_uc2(wf.t2, to, tv)
+        if wf.l1 is not None:
+            wf.l1 = transform_uc1(wf.l1, to, tv)
+        if wf.l2 is not None:
+            wf.l2 = transform_uc2(wf.l2, to, tv)
         return wf
 
 

--- a/vayesta/core/types/wf/ccsd.py
+++ b/vayesta/core/types/wf/ccsd.py
@@ -323,7 +323,7 @@ class UCCSD_WaveFunction(RCCSD_WaveFunction):
         """
         wf = self if inplace else self.copy()
         if isinstance(to, np.ndarray) and len(to) == 2:
-            assert( isinstance(tv, np.ndarray) and len(tv) == 2)
+            assert(isinstance(tv, np.ndarray) and len(tv) == 2)
             trafo = lambda c: dot(c, block_diag(to, tv))
         else:
             trafo = [lambda c: dot(c, x) for x in (block_diag(to[0], tv[0]), block_diag(to[1], tv[1]))]

--- a/vayesta/core/types/wf/ccsd.py
+++ b/vayesta/core/types/wf/ccsd.py
@@ -170,7 +170,24 @@ class RCCSD_WaveFunction(wf_types.WaveFunction):
     def as_fci(self):
         raise NotImplementedError
 
-    def rotate(self, to, tv, inplace=False):
+    def rotate(self, t, inplace=False):
+        """Rotate wavefunction representation to another basis.
+        Only rotations which don't mix occupied and virtual orbitals are supported.
+        Assumes rotated orbitals have same occupancy ordering as originals.
+        """
+        o = self.mo.occ > 0
+        v = self.mo.occ == 0
+
+        to = t[np.ix_(o, o)]
+        tv = t[np.ix_(v, v)]
+        tov = t[np.ix_(o, v)]
+        tvo = t[np.ix_(v, o)]
+        if abs(tov).max() > 1e-12 or abs(tvo).max() > 1e-12:
+            raise ValueError("Provided rotation mixes occupied and virtual orbitals.")
+        return self.rotate_ov(to, tv, inplace=inplace)
+
+
+    def rotate_ov(self, to, tv, inplace=False):
         """Rotate wavefunction representation to another basis.
         Only rotations which don't mix occupied and virtual orbitals are supported.
 
@@ -311,7 +328,32 @@ class UCCSD_WaveFunction(RCCSD_WaveFunction):
         if self.l2 is not None:
             self.l2 = spinalg.multiply(self.l2, len(self.l2)*[factor])
 
-    def rotate(self, to, tv, inplace=False):
+    def rotate(self, t, inplace=False):
+        """Rotate wavefunction representation to another basis.
+        Only rotations which don't mix occupied and virtual orbitals are supported.
+        Assumes rotated orbitals have same occupancy ordering as originals.
+        """
+        # Allow support for same rotation for alpha and beta.
+        if isinstance(t, np.ndarray) and t.ndim == 2:
+            t = (t, t)
+        def get_components(tsp, occ):
+            o = occ > 0
+            v = occ == 0
+            tspo = tsp[np.ix_(o, o)]
+            tspv = tsp[np.ix_(v, v)]
+            tspov = tsp[np.ix_(o, v)]
+            tspvo = tsp[np.ix_(v, o)]
+            if abs(tspov).max() > 1e-12 or abs(tspvo).max() > 1e-12:
+                raise ValueError("Provided rotation mixes occupied and virtual orbitals.")
+            return tspo, tspv
+
+        toa, tva = get_components(t[0], self.mo.alpha.occ)
+        tob, tvb = get_components(t[1], self.mo.beta.occ)
+
+        return self.rotate_ov((toa, tob), (tva, tvb), inplace=inplace)
+
+
+    def rotate_ov(self, to, tv, inplace=False):
         """Rotate wavefunction representation to another basis.
         Only rotations which don't mix occupied and virtual orbitals are supported.
 

--- a/vayesta/core/types/wf/project.py
+++ b/vayesta/core/types/wf/project.py
@@ -1,7 +1,7 @@
 """Utility functions for projection of wave functions."""
 
 import numpy as np
-from vayesta.core.util import einsum
+from vayesta.core.util import einsum, dot
 
 
 def project_c1(c1, p):
@@ -49,7 +49,7 @@ def symmetrize_uc2(c2, inplace=True):
 
 def transform_c1(c1, to, tv):
     if c1 is None: return None
-    return np.dot(to.T, c1, tv)
+    return dot(to.T, c1, tv)
 
 def transform_c2(c2, to, tv, to2=None, tv2=None):
     if c2 is None: return None

--- a/vayesta/core/types/wf/project.py
+++ b/vayesta/core/types/wf/project.py
@@ -1,6 +1,7 @@
 """Utility functions for projection of wave functions."""
 
 import numpy as np
+from vayesta.core.util import einsum
 
 
 def project_c1(c1, p):
@@ -45,3 +46,27 @@ def symmetrize_uc2(c2, inplace=True):
     if len(c2) == 4:
         c2ab = (c2ab + c2[2].transpose(1,0,3,2))/2
     return (c2aa, c2ab, c2bb)
+
+def transform_c1(c1, to, tv):
+    if c1 is None: return None
+    return np.dot(to.T, c1, tv)
+
+def transform_c2(c2, to, tv, to2=None, tv2=None):
+    if c2 is None: return None
+    if to2 is None: to2 = to
+    if tv2 is None: tv2 = tv
+    # Use einsum for now- tensordot would be faster but less readable.
+    return einsum("ijab,iI,jJ,aA,bB->IJAB", c2, to, to2, tv, tv2)
+
+def transform_uc1(c1, to, tv):
+    if c1 is None: return None
+    return (transform_c1(c1[0], to[0], tv[0]),
+            transform_c1(c1[1], to[1], tv[1]))
+
+def transform_uc2(c2, to, tv):
+    if c2 is None: return None
+    c2ba = (c2[2] if len(c2) == 4 else c2[1].transpose(1,0,3,2))
+    return (transform_c2(c2[0], to[0], tv[0]),
+            transform_c2(c2[1], to[0], tv[0], to[1], tv[1]),
+            transform_c2(c2ba, to[1], tv[1], to[0], tv[0]),
+            transform_c2(c2[-1], to[1], tv[1]))

--- a/vayesta/core/types/wf/wf.py
+++ b/vayesta/core/types/wf/wf.py
@@ -65,6 +65,12 @@ class WaveFunction:
     def make_rdm2(self, *args, **kwargs):
         raise AbstractMethodError
 
+    def rotate_ov(self, *args, **kwargs):
+        raise AbstractMethodError
+
+    def rotate(self, *args, **kwargs):
+        raise AbstractMethodError
+
     @staticmethod
     def from_pyscf(obj, **kwargs):
         # HF

--- a/vayesta/ewf/ewf.py
+++ b/vayesta/ewf/ewf.py
@@ -229,7 +229,7 @@ class EWF(Embedding):
     # Defaults
 
     def make_rdm1(self, *args, **kwargs):
-        if self.solver.lower() == 'ccsd':
+        if "cc" in self.solver.lower():
             return self._make_rdm1_ccsd_global_wf(*args, **kwargs)
         if self.solver.lower() == 'mp2':
             return self._make_rdm1_mp2_global_wf(*args, **kwargs)

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -280,8 +280,8 @@ class Fragment(BaseFragment):
             self.log.debugv("Passing fragment option %s to solver.", attr)
             solver_opts[attr] = getattr(self.opts, attr)
 
-        has_actspace = ((solver == "TCCSD") or ("CCSDt" in solver) or
-                        (solver == "EBCC" and self.opts.solver_options['ansatz'] == "CCSDt"))
+        has_actspace = ((solver == "TCCSD") or ("CCSDt'" in solver) or
+                        (solver.upper() == "EBCC" and self.opts.solver_options['ansatz'] == "CCSDt'"))
         if has_actspace:
             # Set CAS orbitals
             if self.opts.c_cas_occ is None:

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -101,7 +101,7 @@ class Fragment(BaseFragment):
         self.solver_results = None
 
     def set_cas(self, iaos=None, c_occ=None, c_vir=None, minao='auto', dmet_threshold=None):
-        """Set complete active space for tailored CCSD"""
+        """Set complete active space for tailored CCSD and active-space CC methods."""
         if dmet_threshold is None:
             dmet_threshold = 2*self.opts.bath_options['dmet_threshold']
         if iaos is not None:

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -100,6 +100,11 @@ class Fragment(BaseFragment):
         # For self-consistent mode
         self.solver_results = None
 
+    def _reset(self, *args, **kwargs):
+        super()._reset(*args, **kwargs)
+        # Need to unset these so can be regenerated each iteration.
+        self.opts.c_cas_occ = self.opts.c_cas_vir = None
+
     def set_cas(self, iaos=None, c_occ=None, c_vir=None, minao='auto', dmet_threshold=None):
         """Set complete active space for tailored CCSD and active-space CC methods."""
         if dmet_threshold is None:

--- a/vayesta/ewf/fragment.py
+++ b/vayesta/ewf/fragment.py
@@ -280,8 +280,9 @@ class Fragment(BaseFragment):
             self.log.debugv("Passing fragment option %s to solver.", attr)
             solver_opts[attr] = getattr(self.opts, attr)
 
-        if solver.upper() == 'TCCSD':
-            solver_opts['tcc'] = True
+        has_actspace = ((solver == "TCCSD") or ("CCSDt" in solver) or
+                        (solver == "EBCC" and self.opts.solver_options['ansatz'] == "CCSDt"))
+        if has_actspace:
             # Set CAS orbitals
             if self.opts.c_cas_occ is None:
                 self.log.warning("Occupied CAS orbitals not set. Setting to occupied DMET cluster orbitals.")
@@ -291,7 +292,8 @@ class Fragment(BaseFragment):
                 self.opts.c_cas_vir = self._dmet_bath.c_cluster_vir
             solver_opts['c_cas_occ'] = self.opts.c_cas_occ
             solver_opts['c_cas_vir'] = self.opts.c_cas_vir
-            solver_opts['tcc_fci_opts'] = self.opts.tcc_fci_opts
+            if solver == "TCCSD":
+                solver_opts['tcc_fci_opts'] = self.opts.tcc_fci_opts
         elif solver.upper() == 'DUMP':
             solver_opts['filename'] = self.opts.solver_options['dumpfile']
         solver_opts['external_corrections'] = self.flags.external_corrections

--- a/vayesta/ewf/ufragment.py
+++ b/vayesta/ewf/ufragment.py
@@ -11,8 +11,14 @@ from vayesta.ewf.fragment import Fragment as RFragment
 
 class Fragment(RFragment, BaseFragment):
 
-    def set_cas(self, *args, **kwargs):
-        raise NotImplementedError()
+    def set_cas(self, iaos=None, c_occ=None, c_vir=None, minao='auto', dmet_threshold=None):
+        """Set complete active space for tailored CCSD and active-space CC methods."""
+        if iaos is not None:
+                raise NotImplementedError("Unrestricted IAO-based CAS not implemented yet.")
+
+        self.opts.c_cas_occ = c_occ
+        self.opts.c_cas_vir = c_vir
+        return c_occ, c_vir
 
     def get_fragment_energy(self, c1, c2, hamil=None, fock=None, axis1='fragment', c2ba_order='ba'):
         """Calculate fragment correlation energy contribution from projected C1, C2.

--- a/vayesta/solver/__init__.py
+++ b/vayesta/solver/__init__.py
@@ -66,7 +66,9 @@ def _get_solver_class_internal(is_uhf, is_eb, solver):
         return coupledRCCSD_Solver
 
     # Now consider general CC ansatzes; these are solved via EBCC.
-    if "CC" in solver:
+    # Note that we support all capitalisations of `ebcc`, but need `CC` to be capitalised when also using this to
+    # specify an ansatz.
+    if "CC" in solver.upper():
         if not _has_ebcc:
             raise ImportError(f"{solver} solver is only accessible via ebcc. Please install ebcc.")
         if is_uhf:
@@ -79,10 +81,10 @@ def _get_solver_class_internal(is_uhf, is_eb, solver):
                 solverclass = EB_REBCC_Solver
             else:
                 solverclass = REBCC_Solver
-        if solver == "EBCC":
+        if solver.upper() == "EBCC":
             # Default to `opts.ansatz`.
             return solverclass
-        if solver[:2] == "EB":
+        if solver[:2].upper() == "EB":
             solver = solver[2:]
         if solver == "CCSD" and is_eb:
             # Need to specify CC level for coupled electron-boson model; throw an error rather than assume.

--- a/vayesta/solver/__init__.py
+++ b/vayesta/solver/__init__.py
@@ -36,7 +36,6 @@ def _get_solver_class(is_uhf, is_eb, solver, log):
 
 
 def _get_solver_class_internal(is_uhf, is_eb, solver):
-    solver = solver.upper()
     # First check if we have a CC approach as implemented in pyscf.
     if solver == "CCSD" and not is_eb:
         # Use pyscf solvers.
@@ -48,13 +47,13 @@ def _get_solver_class_internal(is_uhf, is_eb, solver):
         if is_uhf or is_eb:
             raise ValueError("TCCSD is not implemented for unrestricted or electron-boson calculations!")
         return TRCCSD_Solver
-    if solver == "EXTCCSD":
+    if solver == "extCCSD":
         if is_eb:
             raise ValueError("extCCSD is not implemented for electron-boson calculations!")
         if is_uhf:
             return extUCCSD_Solver
         return extRCCSD_Solver
-    if solver == "COUPLEDCCSD":
+    if solver == "coupledCCSD":
         if is_eb:
             raise ValueError("coupledCCSD is not implemented for electron-boson calculations!")
         if is_uhf:
@@ -83,13 +82,14 @@ def _get_solver_class_internal(is_uhf, is_eb, solver):
             raise ValueError(
                 "Please specify a coupled electron-boson CC ansatz as a solver, for example CCSD-S-1-1,"
                 "rather than CCSD")
-
+        # This is just a wrapper to allow us to use the solver option as the ansatz kwarg in this case.
         def get_right_CC(*args, **kwargs):
-
-            if kwargs.get("ansatz", None) is not None:
-                raise ValueError(
-                    "Desired CC ansatz specified differently in solver and solver_options.ansatz."
-                    "Please use only specify via one approach, or ensure they agree.")
+            setansatz = kwargs.get("ansatz", None)
+            if setansatz is not None:
+                if setansatz != solver:
+                    raise ValueError(
+                        "Desired CC ansatz specified differently in solver and solver_options.ansatz."
+                        "Please use only specify via one approach, or ensure they agree.")
             kwargs["ansatz"] = solver
             return solverclass(*args, **kwargs)
 

--- a/vayesta/solver/__init__.py
+++ b/vayesta/solver/__init__.py
@@ -2,7 +2,6 @@ from vayesta.solver.ccsd import RCCSD_Solver, UCCSD_Solver
 from vayesta.solver.cisd import RCISD_Solver, UCISD_Solver
 from vayesta.solver.coupled_ccsd import coupledRCCSD_Solver
 from vayesta.solver.dump import DumpSolver
-from vayesta.solver.ebcc import REBCC_Solver, UEBCC_Solver, EB_REBCC_Solver, EB_UEBCC_Solver
 from vayesta.solver.ebfci import EB_EBFCI_Solver, EB_UEBFCI_Solver
 from vayesta.solver.ext_ccsd import extRCCSD_Solver, extUCCSD_Solver
 from vayesta.solver.fci import FCI_Solver, UFCI_Solver
@@ -10,6 +9,12 @@ from vayesta.solver.hamiltonian import is_ham, is_uhf_ham, is_eb_ham, ClusterHam
 from vayesta.solver.mp2 import RMP2_Solver, UMP2_Solver
 from vayesta.solver.tccsd import TRCCSD_Solver
 
+try:
+    from vayesta.solver.ebcc import REBCC_Solver, UEBCC_Solver, EB_REBCC_Solver, EB_UEBCC_Solver
+except ImportError:
+    _has_ebcc = False
+else:
+    _has_ebcc = True
 
 def get_solver_class(ham, solver):
     assert (is_ham(ham))
@@ -62,6 +67,8 @@ def _get_solver_class_internal(is_uhf, is_eb, solver):
 
     # Now consider general CC ansatzes; these are solved via EBCC.
     if "CC" in solver:
+        if not _has_ebcc:
+            raise ImportError(f"{solver} solver is only accessible via ebcc. Please install ebcc.")
         if is_uhf:
             if is_eb:
                 solverclass = EB_UEBCC_Solver

--- a/vayesta/solver/ebcc.py
+++ b/vayesta/solver/ebcc.py
@@ -17,13 +17,14 @@ class REBCC_Solver(ClusterSolver):
         max_cycle: int = 200  # Max number of iterations
         conv_tol: float = None  # Convergence energy tolerance
         conv_tol_normt: float = None  # Convergence amplitude tolerance
+        store_as_ccsd: bool = True # Store results as CCSD_WaveFunction
         c_cas_occ: np.array = None  # Hacky place to put active space orbitals.
         c_cas_vir: np.array = None
 
 
     @property
     def is_fCCSD(self):
-        return self.opts.ansatz == "CCSD"
+        return self.opts.store_as_ccsd or self.opts.ansatz == "CCSD"
 
     def kernel(self):
         # Use pyscf mean-field representation.
@@ -71,6 +72,8 @@ class REBCC_Solver(ClusterSolver):
             except TypeError:
                 self.wf = CCSD_WaveFunction(mo, mycc.t1, mycc.t2)
         else:
+            self.log.warning(
+                "Storing EBCC wavefunction as generic wavefunction object; wavefunction-based estimators will work.")
             # Simply alias required quantities for now; this ensures functionality for arbitrary orders of CC via ebcc.
             self.wf = WaveFunction(mo)
             self.wf.make_rdm1 = mycc.make_rdm1_f
@@ -147,6 +150,8 @@ class UEBCC_Solver(UClusterSolver, REBCC_Solver):
                                             to_spin_tuple2(mycc.t2)
                                             )
         else:
+            self.log.warning(
+                "Storing EBCC wavefunction as generic wavefunction object; wavefunction-based estimators will work.")
             # Simply alias required quantities for now; this ensures functionality for arbitrary orders of CC.
             self.wf = WaveFunction(mo)
 

--- a/vayesta/solver/ebcc.py
+++ b/vayesta/solver/ebcc.py
@@ -39,7 +39,7 @@ class REBCC_Solver(ClusterSolver):
             mycc.solve_lambda()
             self.converged = self.converged and mycc.converged_lambda
         # Now just need to wrangle EBCC results into wavefunction format.
-        self.construct_wavefunction(mycc, self.hamil.mo)
+        self.construct_wavefunction(mycc, self.hamil.get_mo(mf_clus.mo_coeff))
 
     def get_space(self, mo_coeff, mo_occ, frozen=None):
         s = self.hamil.orig_mf.get_ovlp()
@@ -78,6 +78,12 @@ class REBCC_Solver(ClusterSolver):
             self.wf = WaveFunction(mo)
             self.wf.make_rdm1 = mycc.make_rdm1_f
             self.wf.make_rdm2 = mycc.make_rdm2_f
+
+        # Need to rotate wavefunction back into original cluster active space.
+        o = mycc.mo_occ > 0
+        v = mycc.mo_occ == 0
+
+        self.wf.rotate(to=mycc.mo_coeff[np.ix_(o, o)], tv=mycc.mo_coeff[np.ix_(v, v)])
 
     def _debug_exact_wf(self, wf):
         assert (self.is_fCCSD)

--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -86,7 +86,7 @@ class RClusterHamiltonian:
 
     @property
     def mo(self):
-        return Orbitals(self.cluster.c_active, occ=self.cluster.nocc_active)
+        return self.get_mo()
 
     @property
     def nelec(self):
@@ -103,6 +103,12 @@ class RClusterHamiltonian:
     def target_space_projector(self, c=None):
         """Projector to the target fragment space within our cluster."""
         return self._fragment.get_fragment_projector(self.cluster.c_active, c)
+
+    def get_mo(self, mo_coeff=None):
+        c = self.cluster.c_active
+        if mo_coeff is not None:
+            c = dot(c, mo_coeff)
+        return Orbitals(c, occ=self.cluster.nocc_active)
 
     # Integrals for the cluster calculations.
 
@@ -459,6 +465,13 @@ class UClusterHamiltonian(RClusterHamiltonian):
     @property
     def nelec(self):
         return self.cluster.nocc_active
+
+    def get_mo(self, mo_coeff=None):
+        c = self.cluster.c_active
+        if mo_coeff is not None:
+            c[0] = dot(c[0], mo_coeff[0])
+            c[1] = dot(c[1], mo_coeff[1])
+        return Orbitals(c, occ=self.cluster.nocc_active)
 
     # Integrals for the cluster calculations.
 

--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -107,6 +107,9 @@ class RClusterHamiltonian:
     def get_mo(self, mo_coeff=None):
         c = self.cluster.c_active
         if mo_coeff is not None:
+            # This specifies the coefficients in the cluster basis used within the calculation.
+            # Note that we should then apply the opposite rotation to the resulting wavefunction, since Vayesta
+            # currently assumes the wavefunction is in the basis of c_active.
             c = dot(c, mo_coeff)
         return Orbitals(c, occ=self.cluster.nocc_active)
 
@@ -469,8 +472,7 @@ class UClusterHamiltonian(RClusterHamiltonian):
     def get_mo(self, mo_coeff=None):
         c = self.cluster.c_active
         if mo_coeff is not None:
-            c[0] = dot(c[0], mo_coeff[0])
-            c[1] = dot(c[1], mo_coeff[1])
+            c = tuple([dot(x, y) for x, y in zip(c, mo_coeff)])
         return Orbitals(c, occ=self.cluster.nocc_active)
 
     # Integrals for the cluster calculations.

--- a/vayesta/tests/solver/test_ebcc.py
+++ b/vayesta/tests/solver/test_ebcc.py
@@ -26,7 +26,7 @@ class TestCCSD(TestCase):
         emb.kernel()
         import ebcc
 
-        cc = ebcc.REBCC(mf, ansatz=key[-1])
+        cc = ebcc.EBCC(mf, ansatz=key[-1])
         cc.kernel()
 
         self.assertAlmostEqual(emb.e_corr, cc.e_corr)
@@ -35,20 +35,20 @@ class TestCCSD(TestCase):
     def test_rccsd_h2(self):
         return self._test(('h2_ccpvdz', 'rhf', 'CCSD'))
 
-    def test_rccsd_water_631g(self):
-        return self._test(('water_631g', 'rhf', 'CCSD'))
+    def test_rccsd_water_sto3g(self):
+        return self._test(('water_sto3g', 'rhf', 'CCSD'))
 
-    def test_uccsd_water_631g(self):
-        return self._test(('water_631g', 'uhf', 'CCSD'))
+    def test_uccsd_water_sto3g(self):
+        return self._test(('water_sto3g', 'uhf', 'CCSD'))
 
-    def test_uccsd_water_cation_631g(self):
-        return self._test(('water_cation_631g', 'uhf', 'CCSD'))
+    def test_uccsd_water_cation_sto3g(self):
+        return self._test(('water_cation_sto3g', 'uhf', 'CCSD'))
 
-    def test_rccsdt_water_631g(self):
-        return self._test(('water_631g', 'rhf', 'CCSDT'))
+    def test_rccsdt_water_sto3g(self):
+        return self._test(('water_sto3g', 'rhf', 'CCSDT'))
 
-    def test_uccsdt_water_cation_631g(self):
-        return self._test(('water_cation_631g', 'uhf', 'CCSDT'))
+    def test_uccsdt_water_cation_sto3g(self):
+        return self._test(('water_cation_sto3g', 'uhf', 'CCSDT'))
 
     def test_rccsdtprime_water_sto3g(self):
         return self._test(('water_sto3g', 'rhf', "CCSDt'", 'CCSDT'))

--- a/vayesta/tests/solver/test_ebcc.py
+++ b/vayesta/tests/solver/test_ebcc.py
@@ -9,49 +9,97 @@ import vayesta.ewf
 from vayesta.tests.common import TestCase
 from vayesta.tests import testsystems
 
-# Note that ebCC currently doesn't support density fitting, so we'll just test non-DF results.
+# Note that ebCC currently doesn't support density fitting, so we're just testing non-DF results here.
 
-@pytest.mark.fast
-class TestCCSD(TestCase):
-    try:
-        import ebcc
-    except ImportError:
-        pytest.skip("Requires cvxpy")
 
-    def _test(self, key):
-        mf = getattr(getattr(testsystems, key[0]), key[1])()
+class TestEBCC(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import ebcc
+        except ImportError:
+            pytest.skip("Requires cvxpy")
 
-        emb = vayesta.ewf.EWF(mf, solver=f'EB{key[2]}', bath_options=dict(bathtype='full'),
+    def _test(self, system, mf, ansatz):
+        # Test a complete bath calculation with given ansatz reproduces full calculation.
+        mf = getattr(getattr(testsystems, system), mf)()
+
+        emb = vayesta.ewf.EWF(mf, solver=f'EB{ansatz}', bath_options=dict(bathtype='full'),
                               solver_options=dict(solve_lambda=False))
         emb.kernel()
         import ebcc
 
-        cc = ebcc.EBCC(mf, ansatz=key[-1])
+        cc = ebcc.EBCC(mf, ansatz=ansatz)
         cc.kernel()
 
         self.assertAlmostEqual(emb.e_corr, cc.e_corr)
         self.assertAlmostEqual(emb.e_tot, cc.e_tot)
 
+    @pytest.mark.fast
     def test_rccsd_h2(self):
-        return self._test(('h2_ccpvdz', 'rhf', 'CCSD'))
+        return self._test('h2_ccpvdz', 'rhf', 'CCSD')
 
+    @pytest.mark.fast
     def test_rccsd_water_sto3g(self):
-        return self._test(('water_sto3g', 'rhf', 'CCSD'))
+        return self._test('water_sto3g', 'rhf', 'CCSD')
 
+    @pytest.mark.fast
     def test_uccsd_water_sto3g(self):
-        return self._test(('water_sto3g', 'uhf', 'CCSD'))
+        return self._test('water_sto3g', 'uhf', 'CCSD')
 
     def test_uccsd_water_cation_sto3g(self):
-        return self._test(('water_cation_sto3g', 'uhf', 'CCSD'))
+        return self._test('water_cation_sto3g', 'uhf', 'CCSD')
 
+    @pytest.mark.fast
     def test_rccsdt_water_sto3g(self):
-        return self._test(('water_sto3g', 'rhf', 'CCSDT'))
+        return self._test('water_sto3g', 'rhf', 'CCSDT')
 
+    @pytest.mark.slow
     def test_uccsdt_water_cation_sto3g(self):
-        return self._test(('water_cation_sto3g', 'uhf', 'CCSDT'))
+        return self._test('water_cation_sto3g', 'uhf', 'CCSDT')
 
-    def test_rccsdtprime_water_sto3g(self):
-        return self._test(('water_sto3g', 'rhf', "CCSDt'", 'CCSDT'))
 
-    def test_uccsdtprime_water_sto3g(self):
-        return self._test(('water_sto3g', 'uhf', "CCSDt'", 'CCSDT'))
+class TestEBCCActSpace(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import ebcc
+        except ImportError:
+            pytest.skip("Requires cvxpy")
+
+    def _test(self, system, mf, actansatz, fullansatz, bathtype='dmet', setcas=False):
+        # Test that active space calculation with complete active space reproduces equivalent calculation using higher-
+        # level approach of active space. This defaults to a DMET bath space.
+        mf = getattr(getattr(testsystems, system), mf)()
+
+        embfull = vayesta.ewf.EWF(mf, solver=f'EB{fullansatz}', bath_options=dict(bathtype=bathtype),
+                              solver_options=dict(solve_lambda=False))
+        embfull.kernel()
+
+        embact = vayesta.ewf.EWF(mf, solver=f'EB{actansatz}', bath_options=dict(bathtype=bathtype),
+                              solver_options=dict(solve_lambda=False))
+        if setcas:
+            # Set up fragmentation, then set CAS to complete cluster space in previous calculation.
+            with embact.iao_fragmentation() as f:
+                f.add_all_atomic_fragments()
+
+            for ffull, fact in zip(embfull.loop(), embact.loop()):
+                fact.set_cas(c_occ=ffull.cluster.c_active_occ, c_vir=ffull.cluster.c_active_vir)
+        embact.kernel()
+
+        self.assertAlmostEqual(embact.e_corr, embfull.e_corr)
+        self.assertAlmostEqual(embact.e_tot, embfull.e_tot)
+
+    @pytest.mark.fast
+    def test_rccsdtprime_water_sto3g_dmet(self):
+        return self._test('water_sto3g', 'rhf', "CCSDt'", 'CCSDT', bathtype='dmet', setcas=False)
+
+    def test_uccsdtprime_water_sto3g_dmet(self):
+        return self._test('water_sto3g', 'uhf', "CCSDt'", 'CCSDT', bathtype='dmet', setcas=False)
+
+    @pytest.mark.slow
+    def test_rccsdtprime_h4_sto3g_setcas_full(self):
+        return self._test('h4_sto3g', 'rhf', "CCSDt'", 'CCSDT', bathtype='full', setcas=True)
+
+    def test_uccsdtprime_h3_sto3g_setcas_full(self):
+        return self._test('h3_sto3g', 'uhf', "CCSDt'", 'CCSDT', bathtype='full', setcas=True)

--- a/vayesta/tests/solver/test_ebcc.py
+++ b/vayesta/tests/solver/test_ebcc.py
@@ -1,0 +1,57 @@
+import pytest
+
+import pyscf
+import pyscf.cc
+
+import vayesta
+import vayesta.ewf
+
+from vayesta.tests.common import TestCase
+from vayesta.tests import testsystems
+
+# Note that ebCC currently doesn't support density fitting, so we'll just test non-DF results.
+
+@pytest.mark.fast
+class TestCCSD(TestCase):
+    try:
+        import ebcc
+    except ImportError:
+        pytest.skip("Requires cvxpy")
+
+    def _test(self, key):
+        mf = getattr(getattr(testsystems, key[0]), key[1])()
+
+        emb = vayesta.ewf.EWF(mf, solver=f'EB{key[2]}', bath_options=dict(bathtype='full'),
+                              solver_options=dict(solve_lambda=False))
+        emb.kernel()
+        import ebcc
+
+        cc = ebcc.REBCC(mf, ansatz=key[-1])
+        cc.kernel()
+
+        self.assertAlmostEqual(emb.e_corr, cc.e_corr)
+        self.assertAlmostEqual(emb.e_tot, cc.e_tot)
+
+    def test_rccsd_h2(self):
+        return self._test(('h2_ccpvdz', 'rhf', 'CCSD'))
+
+    def test_rccsd_water_631g(self):
+        return self._test(('water_631g', 'rhf', 'CCSD'))
+
+    def test_uccsd_water_631g(self):
+        return self._test(('water_631g', 'uhf', 'CCSD'))
+
+    def test_uccsd_water_cation_631g(self):
+        return self._test(('water_cation_631g', 'uhf', 'CCSD'))
+
+    def test_rccsdt_water_631g(self):
+        return self._test(('water_631g', 'rhf', 'CCSDT'))
+
+    def test_uccsdt_water_cation_631g(self):
+        return self._test(('water_cation_631g', 'uhf', 'CCSDT'))
+
+    def test_rccsdtprime_water_sto3g(self):
+        return self._test(('water_sto3g', 'rhf', "CCSDt'", 'CCSDT'))
+
+    def test_uccsdtprime_water_sto3g(self):
+        return self._test(('water_sto3g', 'uhf', "CCSDt'", 'CCSDT'))

--- a/vayesta/tests/solver/test_ebcc.py
+++ b/vayesta/tests/solver/test_ebcc.py
@@ -18,7 +18,7 @@ class TestEBCC(TestCase):
         try:
             import ebcc
         except ImportError:
-            pytest.skip("Requires cvxpy")
+            pytest.skip("Requires ebcc")
 
     def _test(self, system, mf, ansatz):
         # Test a complete bath calculation with given ansatz reproduces full calculation.
@@ -65,7 +65,7 @@ class TestEBCCActSpace(TestCase):
         try:
             import ebcc
         except ImportError:
-            pytest.skip("Requires cvxpy")
+            pytest.skip("Requires ebcc")
 
     def _test(self, system, mf, actansatz, fullansatz, bathtype='dmet', setcas=False):
         # Test that active space calculation with complete active space reproduces equivalent calculation using higher-

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -370,8 +370,11 @@ lih_631g = TestMolecule(atom="Li 0 0 0; H 0 0 1.4", basis="6-31g")
 h2_ccpvdz = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0", basis="cc-pvdz")
 h2_ccpvdz_df = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0", basis="cc-pvdz", auxbasis="cc-pvdz-jkfit")
 
+h3_sto3g = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0", basis="sto3g", spin=1)
 h3_ccpvdz = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0", basis="cc-pvdz", spin=1)
 h3_ccpvdz_df = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0", basis="cc-pvdz", auxbasis="cc-pvdz-jkfit", spin=1)
+
+h4_sto3g = TestMolecule(atom="H1 0 0 0; H2 0 0 1.0; H3 0 1.0 0; H4 0 1.0 1.0", basis="sto3g", spin=0)
 
 heli_631g = TestMolecule(atom="He 0 0 0; Li 0 0 2.0", basis='6-31G', spin=1)
 h6_dz = TestMolecule(atom=molecules.ring('H', 6, 1.0), basis='cc-pVDZ')


### PR DESCRIPTION
Updates the Vayesta interface for solvers from `ebcc`, adding support for CCSDt' active space solvers. Notable background updates are:

- Added functionality to apply rotations to CCSD wavefunctions and run solver calculations in a rotation of the cluster basis.
- Fixed factor of two conversion between certain spin components  of UCCSD T2 amplitudes from `ebcc`.
- Added tests and examples for using solvers from `ebcc` (CCSD, CCSDT and CCSDt').