### PR TITLE
CodeCov Fix Attempt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,8 @@ jobs:
         run: |
           python -m pip install wheel --user
           python -m pip install setuptools --upgrade --user
-
           python -m pip install https://github.com/BoothGroup/dyson/archive/master.zip
-          python -m pip install .[dmet,ebcc] --user
+          python -m pip install -e .[dmet,ebcc] --user
       - name: Run unit tests
         run: |
           python -m pip install pytest pytest-cov --user


### PR DESCRIPTION
This attempts to install Vayesta in editable mode within the github CI. This should hopefully fix the codecov (no guarantees) since we seem to actually be encountering a bug with `coverage.py` itself; for more info see https://github.com/nedbat/coveragepy/issues/1034 or https://stackoverflow.com/questions/72986258/pytest-cov-showing-no-coverage.

It seems like the issue is that since we're installing not in editable mode, we're not technically running the `/vayesta` repository we specify we want coverage for and so no activity is traced. With any luck being in editable mode fixes this, otherwise I'll investigate something else.

Looking at the coverage bot this started after merging https://github.com/BoothGroup/Vayesta/pull/97 and moving from `setup.py` to `pyproject.toml`, so I guess that may have changed this behaviour?