### PR TITLE
Add codecov limit on coverage reduction.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 0.5% drop from the previous base commit coverage
+        threshold: 0.5%


### PR DESCRIPTION
This adds an additional codecov target which should fail if a PR reduces test coverage by more than 0.5%. This is arbitrarily configurable, but this seemed like a level of reduction which should allow large PRs with partial test coverage while prompting consideration if tests are totally absent.

This follows on from #123 , which fixed an issue with coverage calculation introduced in #97 that would've been caught by a check like this.