### PR TITLE
ebcc wavefunctions

### DIFF
--- a/.github/workflows/run_tests.py
+++ b/.github/workflows/run_tests.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
         "--cov=vayesta",
     ]
 
-    if not (len(sys.argv) == 1 or sys.argv[1] != "--with-veryslow"):
+    if len(sys.argv) > 1 and sys.argv[1] == "--with-veryslow":
         args.append("-m veryslow or not veryslow")
 
     raise SystemExit(pytest.main(args))

--- a/.github/workflows/run_tests.py
+++ b/.github/workflows/run_tests.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
         "--cov=vayesta",
     ]
 
-    if len(sys.argv) == 1 or sys.argv[1] != "--with-veryslow":
-        args.append("-m not veryslow")
+    if not (len(sys.argv) == 1 or sys.argv[1] != "--with-veryslow"):
+        args.append("-m veryslow or not veryslow")
 
     raise SystemExit(pytest.main(args))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dyson = [
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
 ]
 ebcc = [
-    "ebcc"
+    "ebcc @ git+https://github.com/BoothGroup/ebcc@master",
 ]
 
 pygnme = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dyson = [
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
 ]
 ebcc = [
-    "ebcc @ git+https://github.com/BoothGroup/ebcc@master",
+    "ebcc",
 ]
 
 pygnme = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib -m 'not veryslow'"
 testpaths = ["vayesta/tests"]
 markers = [
     "fast",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib -k 'not veryslow'"
+addopts = "--import-mode=importlib"
 testpaths = ["vayesta/tests"]
 markers = [
     "fast",

--- a/vayesta/core/qemb/qemb.py
+++ b/vayesta/core/qemb/qemb.py
@@ -103,7 +103,7 @@ class Options(OptionsBase):
             # EBFCI/EBCCSD
             max_boson_occ=2,
             # EBCC
-            ansatz=None, store_as_ccsd=None, fermion_wf=False,
+            ansatz=None, store_as_ccsd=None,
             # Dump
             dumpfile='clusters.h5',
             # MP2

--- a/vayesta/core/types/__init__.py
+++ b/vayesta/core/types/__init__.py
@@ -1,3 +1,4 @@
 from vayesta.core.types.orbitals import *
 from vayesta.core.types.wf import *
 from vayesta.core.types.cluster import *
+from vayesta.core.types.ebwf import *

--- a/vayesta/core/types/ebwf/__init__.py
+++ b/vayesta/core/types/ebwf/__init__.py
@@ -1,8 +1,7 @@
 from vayesta.core.types.ebwf.ebwf import EBWavefunction
-from vayesta.core.types.ebwf.ebccsd import REBCC_WaveFunction, UEBCC_WaveFunction
-
-
-__all__ = [
-        'EBWavefunction',
-        'REBCC_WaveFunction', 'UEBCC_WaveFunction',
-        ]
+try:
+        from vayesta.core.types.ebwf.ebcc import EBCC_WaveFunction, REBCC_WaveFunction, UEBCC_WaveFunction
+except ImportError:
+        _has_ebcc = False
+else:
+        _has_ebcc = True

--- a/vayesta/core/types/ebwf/__init__.py
+++ b/vayesta/core/types/ebwf/__init__.py
@@ -1,0 +1,8 @@
+from vayesta.core.types.ebwf.ebwf import EBWavefunction
+from vayesta.core.types.ebwf.ebccsd import EB_RCCSD_WaveFunction, EB_UCCSD_WaveFunction
+
+
+__all__ = [
+        'EBWavefunction',
+        'EB_RCCSD_WaveFunction', 'EB_UCCSD_WaveFunction',
+        ]

--- a/vayesta/core/types/ebwf/__init__.py
+++ b/vayesta/core/types/ebwf/__init__.py
@@ -1,8 +1,8 @@
 from vayesta.core.types.ebwf.ebwf import EBWavefunction
-from vayesta.core.types.ebwf.ebccsd import EB_RCCSD_WaveFunction, EB_UCCSD_WaveFunction
+from vayesta.core.types.ebwf.ebccsd import REBCC_WaveFunction, UEBCC_WaveFunction
 
 
 __all__ = [
         'EBWavefunction',
-        'EB_RCCSD_WaveFunction', 'EB_UCCSD_WaveFunction',
+        'REBCC_WaveFunction', 'UEBCC_WaveFunction',
         ]

--- a/vayesta/core/types/ebwf/ebccsd.py
+++ b/vayesta/core/types/ebwf/ebccsd.py
@@ -6,7 +6,7 @@ import numpy as np
 # Note that we don't subclass the existing CCSD_WaveFunction class since we need to use ebcc as a backend, rather than
 # pyscf.
 
-class EB_RCCSD_WaveFunction(ebwf.EBWavefunction):
+class REBCC_WaveFunction(ebwf.EBWavefunction):
 
     _spin_type = "R"
     _driver = ebcc.REBCC
@@ -21,16 +21,21 @@ class EB_RCCSD_WaveFunction(ebwf.EBWavefunction):
             self.ansatz = ebcc.Ansatz.from_string(ansatz)
         self._eqns = self.ansatz._get_eqns(self._spin_type)
 
-    # This allows us to access all relevant amplitudes and lambdas as attributes of the wavefunction object.
-    def __getattribute__(self, key):
-        amps = super(EB_RCCSD_WaveFunction, self).__getattribute__("amplitudes")
-        lambdas = super(EB_RCCSD_WaveFunction, self).__getattribute__("lambdas")
-        if key in amps._keys:
-            return amps[key]
-        if lambdas is not None:
-            if key in lambdas._keys:
-                return lambdas[key]
-        return super(EB_RCCSD_WaveFunction, self).__getattribute__(key)
+    @property
+    def t1(self):
+        return self.amplitudes.t1
+
+    @property
+    def t2(self):
+        return self.amplitudes.t2
+
+    @property
+    def l1(self):
+        return None if self.lambdas is None else self.lambdas.l1
+
+    @property
+    def l2(self):
+        return None if self.lambdas is None else self.lambdas.l2
 
     def _load_function(self, *args, **kwargs):
         return self._driver._load_function(self, *args, **kwargs)
@@ -60,6 +65,38 @@ class EB_RCCSD_WaveFunction(ebwf.EBWavefunction):
         return self._driver.make_rdm1_f(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
 
 
-class EB_UCCSD_WaveFunction(EB_RCCSD_WaveFunction):
+class UEBCC_WaveFunction(REBCC_WaveFunction):
     _spin_type = "U"
     _driver = ebcc.UEBCC
+
+    @property
+    def t1a(self):
+        return self.amplitudes.t1.aa
+
+    @property
+    def t1b(self):
+        return self.amplitudes.t1.bb
+
+    @property
+    def t1(self):
+        return (self.t1a, self.t1b)
+
+    @property
+    def t2aa(self):
+        return self.amplitudes.t2.aaaa
+
+    @property
+    def t2ab(self):
+        return self.amplitudes.t2.aabb
+
+    @property
+    def t2ba(self):
+        return self.amplitudes.t2.bbaa
+
+    @property
+    def t2bb(self):
+        return self.amplitudes.t2.bbbb
+
+    @property
+    def t2(self):
+        return (self.t2aa, self.t2ab, self.t2bb)

--- a/vayesta/core/types/ebwf/ebccsd.py
+++ b/vayesta/core/types/ebwf/ebccsd.py
@@ -22,6 +22,11 @@ class REBCC_WaveFunction(ebwf.EBWavefunction):
         self._eqns = self.ansatz._get_eqns(self._spin_type)
 
     @property
+    def name(self):
+        """Get a string representation of the method name."""
+        return self._spin_type + self.ansatz.name
+
+    @property
     def t1(self):
         return self.amplitudes.t1
 
@@ -63,6 +68,18 @@ class REBCC_WaveFunction(ebwf.EBWavefunction):
 
     def make_rdm1(self, *args, **kwargs):
         return self._driver.make_rdm1_f(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
+
+    def make_rdm2(self, *args, **kwargs):
+        return self._driver.make_rdm2_f(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
+
+    def make_rdm1_b(self, *args, **kwargs):
+        return self._driver.make_rdm1_b(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
+
+    def make_sing_b_dm(self, *args, **kwargs):
+        return self._driver.make_sing_b_dm(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
+
+    def make_eb_coup_rdm(self, *args, **kwargs):
+        return self._driver.make_eb_coup_rdm(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
 
 
 class UEBCC_WaveFunction(REBCC_WaveFunction):

--- a/vayesta/core/types/ebwf/ebccsd.py
+++ b/vayesta/core/types/ebwf/ebccsd.py
@@ -1,0 +1,65 @@
+from vayesta.core.types import ebwf
+
+import ebcc
+import numpy as np
+
+# Note that we don't subclass the existing CCSD_WaveFunction class since we need to use ebcc as a backend, rather than
+# pyscf.
+
+class EB_RCCSD_WaveFunction(ebwf.EBWavefunction):
+
+    _spin_type = "R"
+    _driver = ebcc.REBCC
+
+    def __init__(self, mo, ansatz, amplitudes, lambdas=None, mbos=None, projector=None):
+        super().__init__(mo, mbos, projector)
+        self.amplitudes = amplitudes
+        self.lambdas = lambdas
+        if isinstance(ansatz, ebcc.Ansatz):
+            self.ansatz = ansatz
+        else:
+            self.ansatz = ebcc.Ansatz.from_string(ansatz)
+        self._eqns = self.ansatz._get_eqns(self._spin_type)
+
+    # This allows us to access all relevant amplitudes and lambdas as attributes of the wavefunction object.
+    def __getattribute__(self, key):
+        amps = super(EB_RCCSD_WaveFunction, self).__getattribute__("amplitudes")
+        lambdas = super(EB_RCCSD_WaveFunction, self).__getattribute__("lambdas")
+        if key in amps._keys:
+            return amps[key]
+        if lambdas is not None:
+            if key in lambdas._keys:
+                return lambdas[key]
+        return super(EB_RCCSD_WaveFunction, self).__getattribute__(key)
+
+    def _load_function(self, *args, **kwargs):
+        return self._driver._load_function(self, *args, **kwargs)
+
+    def _pack_codegen_kwargs(self, *extra_kwargs, eris=False):
+        """
+        Pack all the possible keyword arguments for generated code
+        into a dictionary.
+        """
+        eris = False
+        # This is always accessed but never used for any density matrix calculation.
+        g = ebcc.util.Namespace()
+        g["boo"] = g["bov"] = g["bvo"] = g["bvv"] = np.zeros((self.nbos, 0, 0))
+        kwargs = dict(
+            v=eris,
+            g=g,
+            nocc=self.mo.nocc,
+            nvir=self.mo.nvir,
+            nbos=self.nbos,
+        )
+        for kw in extra_kwargs:
+            if kw is not None:
+                kwargs.update(kw)
+        return kwargs
+
+    def make_rdm1(self, *args, **kwargs):
+        return self._driver.make_rdm1_f(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
+
+
+class EB_UCCSD_WaveFunction(EB_RCCSD_WaveFunction):
+    _spin_type = "U"
+    _driver = ebcc.UEBCC

--- a/vayesta/core/types/ebwf/ebccsd.py
+++ b/vayesta/core/types/ebwf/ebccsd.py
@@ -1,18 +1,23 @@
 from vayesta.core.types import ebwf
+from vayesta.core.types import RCCSD_WaveFunction, UCCSD_WaveFunction
+from vayesta.core import spinalg
+from vayesta.core.util import callif
 
 import ebcc
 import numpy as np
 
-# Note that we don't subclass the existing CCSD_WaveFunction class since we need to use ebcc as a backend, rather than
-# pyscf.
+from copy import deepcopy
 
-class REBCC_WaveFunction(ebwf.EBWavefunction):
+
+# Subclass existing CC methods only for the various utility functions (projection, symmetrisation etc).
+# Just need to set properties to correctly interact with the ebcc storage objects.
+class REBCC_WaveFunction(ebwf.EBWavefunction, RCCSD_WaveFunction):
 
     _spin_type = "R"
     _driver = ebcc.REBCC
 
     def __init__(self, mo, ansatz, amplitudes, lambdas=None, mbos=None, projector=None):
-        super().__init__(mo, mbos, projector)
+        super(ebwf.EBWavefunction, self).__init__(mo, mbos, projector)
         self.amplitudes = amplitudes
         self.lambdas = lambdas
         if isinstance(ansatz, ebcc.Ansatz):
@@ -30,17 +35,37 @@ class REBCC_WaveFunction(ebwf.EBWavefunction):
     def t1(self):
         return self.amplitudes.t1
 
+    @t1.setter
+    def t1(self, value):
+        self.amplitudes.t1 = value
+
     @property
     def t2(self):
         return self.amplitudes.t2
+
+    @t2.setter
+    def t2(self, value):
+        self.amplitudes.t2 = value
 
     @property
     def l1(self):
         return None if self.lambdas is None else self.lambdas.l1
 
+    @l1.setter
+    def l1(self, value):
+        if self.lambdas is None:
+            self.lambdas = ebcc.util.Namespace()
+        self.lambdas.l1 = value
+
     @property
     def l2(self):
         return None if self.lambdas is None else self.lambdas.l2
+
+    @l2.setter
+    def l2(self, value):
+        if self.lambdas is None:
+            self.lambdas = ebcc.util.Namespace()
+        self.lambdas.l2 = value
 
     def _load_function(self, *args, **kwargs):
         return self._driver._load_function(self, *args, **kwargs)
@@ -81,8 +106,18 @@ class REBCC_WaveFunction(ebwf.EBWavefunction):
     def make_eb_coup_rdm(self, *args, **kwargs):
         return self._driver.make_eb_coup_rdm(self, eris=False, amplitudes=self.amplitudes, lambdas=self.lambdas, hermitise=True)
 
+    def copy(self):
+        proj = callif(spinalg.copy, self.projector)
+        type(self)(self.mo.copy(), deepcopy(self.ansatz), deepcopy(self.amplitudes), deepcopy(self.lambdas),
+                   self.mbos.copy(), proj)
 
-class UEBCC_WaveFunction(REBCC_WaveFunction):
+    def as_ccsd(self):
+        proj = callif(spinalg.copy, self.projector)
+        return type(self)(self.mo.copy(), "CCSD", deepcopy(self.amplitudes), deepcopy(self.lambdas),
+                          self.mbos.copy(), proj)
+
+
+class UEBCC_WaveFunction(REBCC_WaveFunction, UCCSD_WaveFunction):
     _spin_type = "U"
     _driver = ebcc.UEBCC
 
@@ -97,6 +132,11 @@ class UEBCC_WaveFunction(REBCC_WaveFunction):
     @property
     def t1(self):
         return (self.t1a, self.t1b)
+
+    @t1.setter
+    def t1(self, value):
+        self.amplitudes.t1.aa = value[0]
+        self.amplitudes.t1.bb = value[1]
 
     @property
     def t2aa(self):
@@ -117,6 +157,67 @@ class UEBCC_WaveFunction(REBCC_WaveFunction):
     @property
     def t2(self):
         return (self.t2aa, self.t2ab, self.t2bb)
+
+    @t2.setter
+    def t2(self, value):
+        self.amplitudes.t2.aaaa = value[0]
+        self.amplitudes.t2.aabb = value[1]
+        self.amplitudes.t2.bbbb = value[-1]
+        if len(value) == 4:
+            self.amplitudes.t2.bbaa = value[2]
+        else:
+            self.amplitudes.t2.bbaa = value[1].transpose(1, 0, 3, 2)
+
+    @property
+    def l1a(self):
+        return None if self.lambdas is None else self.lambdas.l1.aa
+
+    @property
+    def l1b(self):
+        return None if self.lambdas is None else self.lambdas.l1.bb
+
+    @property
+    def l1(self):
+        return None if self.lambdas is None else (self.l1a, self.l1b)
+
+    @l1.setter
+    def l1(self, value):
+        if self.lambdas is None:
+            self.lambdas = ebcc.util.Namespace()
+        self.lambdas.l1.aa = value[0]
+        self.lambdas.l1.bb = value[1]
+
+    @property
+    def l2aaaa(self):
+        return None if self.lambdas is None else self.lambdas.l2.aaaa
+
+    @property
+    def l2aabb(self):
+        return None if self.lambdas is None else self.lambdas.l2.aabb
+
+    @property
+    def l2bbaa(self):
+        return None if self.lambdas is None else self.lambdas.l2.bbaa
+
+    @property
+    def l2bbbb(self):
+        return None if self.lambdas is None else self.lambdas.l2.bbbb
+
+    @property
+    def l2(self):
+        return None if self.lambdas is None else (self.l2aaaa, self.l2aabb, self.l2bbbb)
+
+    @l2.setter
+    def l2(self, value):
+        if self.lambdas is None:
+            self.lambdas = ebcc.util.Namespace()
+        self.lambdas.l2.aaaa = value[0]
+        self.lambdas.l2.aabb = value[1]
+        self.lambdas.l2.bbbb = value[-1]
+        if len(value) == 4:
+            self.lambdas.l2.bbaa = value[2]
+        else:
+            self.lambdas.l2.bbaa = value[1].transpose(1, 0, 3, 2)
 
     def _pack_codegen_kwargs(self, *extra_kwargs, eris=False):
         """

--- a/vayesta/core/types/ebwf/ebccsd.py
+++ b/vayesta/core/types/ebwf/ebccsd.py
@@ -117,3 +117,26 @@ class UEBCC_WaveFunction(REBCC_WaveFunction):
     @property
     def t2(self):
         return (self.t2aa, self.t2ab, self.t2bb)
+
+    def _pack_codegen_kwargs(self, *extra_kwargs, eris=False):
+        """
+        Pack all the possible keyword arguments for generated code
+        into a dictionary.
+        """
+        eris = False
+        # This is always accessed but never used for any density matrix calculation.
+        g = ebcc.util.Namespace()
+        g["aa"] = ebcc.util.Namespace()
+        g["aa"]["boo"] = g["aa"]["bov"] = g["aa"]["bvo"] = g["aa"]["bvv"] = np.zeros((self.nbos, 0, 0))
+        g["bb"] = g["aa"]
+        kwargs = dict(
+            v=eris,
+            g=g,
+            nocc=self.mo.nocc,
+            nvir=self.mo.nvir,
+            nbos=self.nbos,
+        )
+        for kw in extra_kwargs:
+            if kw is not None:
+                kwargs.update(kw)
+        return kwargs

--- a/vayesta/core/types/ebwf/ebwf.py
+++ b/vayesta/core/types/ebwf/ebwf.py
@@ -1,12 +1,14 @@
-import numpy as np
-
 from vayesta.core.types import wf
-from vayesta.core.util import *
+from vayesta.core.util import AbstractMethodError
 
-class EBWavefunction(wf.Wavefunction):
-    def __init__(self, mo, nbos, projector=None):
-        super().__init(mo, projector)
-        self.nbos = nbos
+class EBWavefunction(wf.WaveFunction):
+    def __init__(self, mo, mbos, projector=None):
+        super().__init__(mo, projector)
+        self.mbos = mbos
+
+    @property
+    def nbos(self):
+        return 0 if self.mbos is None else self.mbos.nbos
 
     def __repr__(self):
         return "%s(norb= %r, nocc= %r, nvir=%r, nbos= %r)" % (self.__class__.__name__, self.norb, self.nocc, self.nvir, self.nbos)
@@ -16,4 +18,3 @@ class EBWavefunction(wf.Wavefunction):
 
     def make_rdm_bb(self, *args, **kwargs):
         raise AbstractMethodError
-

--- a/vayesta/core/types/ebwf/ebwf.py
+++ b/vayesta/core/types/ebwf/ebwf.py
@@ -2,7 +2,7 @@ from vayesta.core.types import wf
 from vayesta.core.util import AbstractMethodError
 
 class EBWavefunction(wf.WaveFunction):
-    def __init__(self, mo, mbos, projector=None):
+    def __init__(self, mo, mbos=None, projector=None):
         super().__init__(mo, projector)
         self.mbos = mbos
 

--- a/vayesta/core/types/ebwf/ebwf.py
+++ b/vayesta/core/types/ebwf/ebwf.py
@@ -1,9 +1,10 @@
-from vayesta.core.types import wf
+from vayesta.core.types.wf import WaveFunction
 from vayesta.core.util import AbstractMethodError
 
-class EBWavefunction(wf.WaveFunction):
+class EBWavefunction(WaveFunction):
+
     def __init__(self, mo, mbos=None, projector=None):
-        super().__init__(mo, projector)
+        WaveFunction.__init__(self, mo, projector)
         self.mbos = mbos
 
     @property

--- a/vayesta/core/types/wf/project.py
+++ b/vayesta/core/types/wf/project.py
@@ -65,8 +65,11 @@ def transform_uc1(c1, to, tv):
 
 def transform_uc2(c2, to, tv):
     if c2 is None: return None
-    c2ba = (c2[2] if len(c2) == 4 else c2[1].transpose(1,0,3,2))
-    return (transform_c2(c2[0], to[0], tv[0]),
-            transform_c2(c2[1], to[0], tv[0], to[1], tv[1]),
-            transform_c2(c2ba, to[1], tv[1], to[0], tv[0]),
-            transform_c2(c2[-1], to[1], tv[1]))
+    c2aa = transform_c2(c2[0], to[0], tv[0])
+    c2ab = transform_c2(c2[1], to[0], tv[0], to[1], tv[1])
+    c2bb = transform_c2(c2[-1], to[1], tv[1])
+    if len(c2) == 4:
+        c2ba = transform_c2(c2[2], to[1], tv[1], to[0], tv[0])
+        return c2aa, c2ab, c2ba, c2bb
+    else:
+        return c2aa, c2ab, c2bb

--- a/vayesta/edmet/fragment.py
+++ b/vayesta/edmet/fragment.py
@@ -688,7 +688,7 @@ class EDMETFragment(DMETFragment):
         dm2 = wf.make_rdm2()
         if self.nbos > 0:
             self.check_qba_approx(dm1)
-        dm_eb = wf.make_rdmeb()
+        dm_eb = wf.make_rdm_eb()
         self._results = results = self.Results(fid=self.id, n_active=self.cluster.norb_active,
                 converged=True, wf=wf, dm1=dm1, dm2=dm2, dm_eb=dm_eb)
         results.e1, results.e2, results.e_fb = self.get_edmet_energy_contrib()

--- a/vayesta/ewf/ewf.py
+++ b/vayesta/ewf/ewf.py
@@ -27,8 +27,6 @@ class Options(Embedding.Options):
     # --- Bath settings
     bath_options: dict = Embedding.Options.change_dict_defaults('bath_options',
             bathtype='mp2', threshold=1e-8)
-    solver_options: dict = Embedding.Options.change_dict_defaults('solver_options',
-            fermion_wf=True)
     #ewdmet_max_order: int = 1
     # If multiple bno thresholds are to be calculated, we can project integrals and amplitudes from a previous larger cluster:
     project_eris: bool = False          # Project ERIs from a pervious larger cluster (corresponding to larger eta), can result in a loss of accuracy especially for large basis sets!

--- a/vayesta/solver/ebcc.py
+++ b/vayesta/solver/ebcc.py
@@ -2,7 +2,7 @@ import dataclasses
 
 import numpy as np
 
-from vayesta.core.types import WaveFunction, CCSD_WaveFunction
+from vayesta.core.types import WaveFunction, CCSD_WaveFunction, EBCC_WaveFunction
 from vayesta.core.util import dot, einsum
 from vayesta.solver.solver import ClusterSolver, UClusterSolver
 import ebcc
@@ -17,14 +17,9 @@ class REBCC_Solver(ClusterSolver):
         max_cycle: int = 200  # Max number of iterations
         conv_tol: float = None  # Convergence energy tolerance
         conv_tol_normt: float = None  # Convergence amplitude tolerance
-        store_as_ccsd: bool = True # Store results as CCSD_WaveFunction
+        store_as_ccsd: bool = False # Store results as CCSD_WaveFunction
         c_cas_occ: np.array = None  # Hacky place to put active space orbitals.
         c_cas_vir: np.array = None
-
-
-    @property
-    def is_fCCSD(self):
-        return self.opts.store_as_ccsd or self.opts.ansatz == "CCSD"
 
     def kernel(self):
         # Use pyscf mean-field representation.
@@ -67,25 +62,18 @@ class REBCC_Solver(ClusterSolver):
         return opts
 
     def construct_wavefunction(self, mycc, mo):
-        if self.is_fCCSD:
+        if self.opts.store_as_ccsd:
             # Can use existing functionality
             try:
                 self.wf = CCSD_WaveFunction(mo, mycc.t1, mycc.t2, l1=mycc.l1.T, l2=mycc.l2.transpose(2, 3, 0, 1))
             except TypeError:
                 self.wf = CCSD_WaveFunction(mo, mycc.t1, mycc.t2)
-            self.wf.rotate(t=mycc.mo_coeff.T, inplace=True)
         else:
-            if not (np.allclose(mycc.mo_coeff, np.eye(mycc.nmo), atol=1e-8)):
-                raise ValueError("Generic wavefunction construction only works for canonical orbitals, please use "
-                                 "`store_as_ccsd=True' in solver_options")
-            self.log.warning(
-                "Storing EBCC wavefunction as generic wavefunction object; wavefunction-based estimators will not work.")
-            # Simply alias required quantities for now; this could allow functionality for arbitrary orders of CC via ebcc.
-            self.wf = WaveFunction(mo)
-            self.wf.make_rdm1 = mycc.make_rdm1_f
-            self.wf.make_rdm2 = mycc.make_rdm2_f
+
+            self.wf = EBCC_WaveFunction(mo, mycc.ansatz, mycc.amplitudes, mycc.lambdas, None)
 
         # Need to rotate wavefunction back into original cluster active space.
+        self.wf.rotate(t=mycc.mo_coeff.T, inplace=True)
 
     def _debug_exact_wf(self, wf):
         assert (self.is_fCCSD)
@@ -140,7 +128,7 @@ class UEBCC_Solver(UClusterSolver, REBCC_Solver):
 
     # This should automatically work other than ensuring spin components are in a tuple.
     def construct_wavefunction(self, mycc, mo):
-        if self.is_fCCSD:
+        if self.opts.store_as_ccsd:
             # Can use existing functionality
             def to_spin_tuple1(x):
                 return x.aa, x.bb
@@ -167,27 +155,11 @@ class UEBCC_Solver(UClusterSolver, REBCC_Solver):
                                             to_spin_tuple1(mycc.t1),
                                             to_spin_tuple2(mycc.t2)
                                             )
-            self.wf.rotate(t=[x.T for x in mycc.mo_coeff], inplace=True)
         else:
-            # Simply alias required quantities for now; this ensures functionality for arbitrary orders of CC.
-            self.wf = WaveFunction(mo)
-            if not (np.allclose(mycc.mo_coeff[0], np.eye(mycc.nmo), atol=1e-8) and
-                    np.allclose(mycc.mo_coeff[1], np.eye(mycc.nmo), atol=1e-8)):
-                raise ValueError("Generic wavefunction construction only works for canonical orbitals, please use "
-                                 "`store_as_ccsd=True' in solver_options")
-            self.log.warning(
-                "Storing EBCC wavefunction as generic wavefunction object; wavefunction-based estimators will not work.")
-            def make_rdm1(*args, **kwargs):
-                dm = mycc.make_rdm1_f(*args, **kwargs)
-                return (dm.aa, dm.bb)
+            self.wf = EBCC_WaveFunction(mo, mycc.ansatz, mycc.amplitudes, mycc.lambdas, None)
 
-            self.wf.make_rdm1 = make_rdm1
+        self.wf.rotate(t=[x.T for x in mycc.mo_coeff], inplace=True)
 
-            def make_rdm2(*args, **kwargs):
-                dm = mycc.make_rdm2_f(*args, **kwargs)
-                return (dm.aaaa, dm.aabb, dm.bbbb)
-
-            self.wf.make_rdm2 = make_rdm2
 
     def _debug_exact_wf(self, wf):
         mo = self.hamil.mo
@@ -225,13 +197,7 @@ class EB_REBCC_Solver(REBCC_Solver):
     @dataclasses.dataclass
     class Options(REBCC_Solver.Options):
         ansatz: str = "CCSD-S-1-1"
-        fermion_wf: bool = False
-
-    @property
-    def is_fCCSD(self):
-        if self.opts.fermion_wf:
-            return super().is_fCCSD
-        return False
+        store_as_ccsd: bool = False  # Store results as fermionic CCSD_WaveFunction
 
     def get_nonnull_solver_opts(self):
         opts = super().get_nonnull_solver_opts()
@@ -243,18 +209,6 @@ class EB_REBCC_Solver(REBCC_Solver):
         # EBCC wants contribution  g_{xpq} p^\\dagger q b; need to transpose to get this contribution.
         return self.hamil.couplings.transpose(0, 2, 1)
 
-    def construct_wavefunction(self, mycc, mo):
-        super().construct_wavefunction(mycc, mo)
-
-        def make_rdmeb(*args, **kwargs):
-            dm = mycc.make_eb_coup_rdm()
-            # We just want the bosonic excitation component.
-            dm = dm[0].transpose(1, 2, 0)
-            return (dm / 2, dm / 2)
-
-        self.wf.make_rdmeb = make_rdmeb
-
-
 class EB_UEBCC_Solver(EB_REBCC_Solver, UEBCC_Solver):
     @dataclasses.dataclass
     class Options(UEBCC_Solver.Options, EB_REBCC_Solver.Options):
@@ -263,17 +217,6 @@ class EB_UEBCC_Solver(EB_REBCC_Solver, UEBCC_Solver):
     def get_couplings(self):
         # EBCC wants contribution  g_{xpq} p^\\dagger q b; need to transpose to get this contribution.
         return tuple([x.transpose(0, 2, 1) for x in self.hamil.couplings])
-
-    def construct_wavefunction(self, mycc, mo):
-        super().construct_wavefunction(mycc, mo)
-
-        def make_rdmeb(*args, **kwargs):
-            dm = mycc.make_eb_coup_rdm()
-            # We just want the bosonic excitation component.
-            dm = (dm.aa[0].transpose(1, 2, 0), dm.bb[0].transpose(1, 2, 0))
-            return dm
-
-        self.wf.make_rdmeb = make_rdmeb
 
 
 def gen_space(c_occ, c_vir, co_active=None, cv_active=None, frozen_orbs=None):

--- a/vayesta/solver/ebfci.py
+++ b/vayesta/solver/ebfci.py
@@ -26,7 +26,7 @@ class EB_EBFCI_Solver(ClusterSolver):
         self.wf = WaveFunction(self.hamil.mo)
         self.wf.make_rdm1 = lambda *args, **kwargs: solver.make_rdm1(*args, **kwargs)
         self.wf.make_rdm2 = lambda *args, **kwargs: solver.make_rdm2(*args, **kwargs)
-        self.wf.make_rdmeb = lambda *args, **kwargs: np.array(solver.make_rdm_eb(*args, **kwargs)) + \
+        self.wf.make_rdm_eb = lambda *args, **kwargs: np.array(solver.make_rdm_eb(*args, **kwargs)) + \
                                                      np.array(
                                                          self.hamil.get_eb_dm_polaritonic_shift(self.wf.make_rdm1()))
         self.wf.make_dd_moms = lambda max_mom, *args, **kwargs: solver.make_dd_moms(max_mom, *args, **kwargs)

--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -748,6 +748,8 @@ class EB_RClusterHamiltonian(RClusterHamiltonian):
         self.bos_freqs = self._fragment.bos_freqs
         if self.opts.polaritonic_shift:
             self.set_polaritonic_shift(self.bos_freqs, self.unshifted_couplings)
+        else:
+            self._polaritonic_shift = None
 
     @property
     def polaritonic_shift(self):

--- a/vayesta/tests/core/wf/test_ebcc_wf.py
+++ b/vayesta/tests/core/wf/test_ebcc_wf.py
@@ -1,0 +1,78 @@
+import pytest
+
+import vayesta
+import vayesta.ewf
+
+from vayesta.tests.common import TestCase
+from vayesta.tests import testsystems
+
+
+class TestEBCCWavefunctions(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import ebcc
+        except ImportError:
+            pytest.skip("Requires ebcc")
+
+    def _test(self, system, mf, ansatz):
+        assert(mf in ["rhf", "uhf"])
+        # Test a complete bath calculation with given ansatz reproduces full calculation.
+        mymf = getattr(getattr(testsystems, system), mf)()
+
+        emborig = vayesta.ewf.EWF(mymf, solver=f'EB{ansatz}', bath_options=dict(bathtype='dmet'),
+                              solver_options=dict(solve_lambda=True, store_as_ccsd=True))
+        with emborig.iao_fragmentation() as f:
+            f.add_atomic_fragment([0])
+        emborig.kernel()
+
+        f = emborig.fragments[0]
+
+        wf1 = f._results.wf
+
+        f.opts.solver_options['store_as_ccsd'] = False
+        f._results = None
+        f._hamil = None
+        f.kernel()
+        wf2 = f._results.wf
+
+        if mf == "rhf":
+            attributes = ["t1", "t2", "l1", "l2"]
+        elif mf == "uhf":
+            attributes = ["t1a", "t1b", "t2aa", "t2ab", "t2bb", "l1a", "l1b", "l2aa", "l2ab", "l2bb"]
+
+        for attr in attributes:
+            self.assertAllclose(getattr(wf1, attr), getattr(wf2, attr))
+
+        if ansatz == "CCSD":
+            # Should only be the same for CCSD.
+            if mf == "rhf":
+                self.assertAllclose(wf1.make_rdm1(), wf2.make_rdm1())
+            elif mf == "uhf":
+                dmorig = wf1.make_rdm1()
+                dmnew = wf2.make_rdm1()
+                self.assertAllclose(dmorig[0], dmnew[0])
+                self.assertAllclose(dmorig[1], dmnew[1])
+
+    @pytest.mark.fast
+    def test_rccsd_h2(self):
+        return self._test('h2_ccpvdz', 'rhf', 'CCSD')
+
+    @pytest.mark.fast
+    def test_rccsd_water_sto3g(self):
+        return self._test('water_sto3g', 'rhf', 'CCSD')
+
+    @pytest.mark.fast
+    def test_uccsd_water_sto3g(self):
+        return self._test('water_sto3g', 'uhf', 'CCSD')
+
+    def test_uccsd_water_cation_sto3g(self):
+        return self._test('water_cation_sto3g', 'uhf', 'CCSD')
+
+    @pytest.mark.fast
+    def test_rccsdt_water_sto3g(self):
+        return self._test('water_sto3g', 'rhf', 'CCSDT')
+
+    @pytest.mark.veryslow
+    def test_uccsdt_water_cation_sto3g(self):
+        return self._test('water_cation_sto3g', 'uhf', 'CCSDT')

--- a/vayesta/tests/core/wf/test_ebcc_wf.py
+++ b/vayesta/tests/core/wf/test_ebcc_wf.py
@@ -73,6 +73,6 @@ class TestEBCCWavefunctions(TestCase):
     def test_rccsdt_water_sto3g(self):
         return self._test('water_sto3g', 'rhf', 'CCSDT')
 
-    @pytest.mark.veryslow
+    @pytest.mark.slow
     def test_uccsdt_water_cation_sto3g(self):
         return self._test('water_cation_sto3g', 'uhf', 'CCSDT')

--- a/vayesta/tests/solver/test_ebcc.py
+++ b/vayesta/tests/solver/test_ebcc.py
@@ -51,7 +51,7 @@ class TestEBCC(TestCase):
     def test_rccsdt_water_sto3g(self):
         return self._test('water_sto3g', 'rhf', 'CCSDT')
 
-    @pytest.mark.veryslow
+    @pytest.mark.slow
     def test_uccsdt_water_cation_sto3g(self):
         return self._test('water_cation_sto3g', 'uhf', 'CCSDT')
 
@@ -94,7 +94,7 @@ class TestEBCCActSpace(TestCase):
     def test_uccsdtprime_water_sto3g_dmet(self):
         return self._test('water_sto3g', 'uhf', "CCSDt'", 'CCSDT', bathtype='dmet', setcas=False)
 
-    @pytest.mark.vslow
+    @pytest.mark.slow
     def test_rccsdtprime_h4_sto3g_setcas_full(self):
         return self._test('h4_sto3g', 'rhf', "CCSDt'", 'CCSDT', bathtype='full', setcas=True)
 

--- a/vayesta/tests/solver/test_ebcc.py
+++ b/vayesta/tests/solver/test_ebcc.py
@@ -1,8 +1,5 @@
 import pytest
 
-import pyscf
-import pyscf.cc
-
 import vayesta
 import vayesta.ewf
 
@@ -22,14 +19,14 @@ class TestEBCC(TestCase):
 
     def _test(self, system, mf, ansatz):
         # Test a complete bath calculation with given ansatz reproduces full calculation.
-        mf = getattr(getattr(testsystems, system), mf)()
+        mymf = getattr(getattr(testsystems, system), mf)()
 
-        emb = vayesta.ewf.EWF(mf, solver=f'EB{ansatz}', bath_options=dict(bathtype='full'),
-                              solver_options=dict(solve_lambda=False))
+        emb = vayesta.ewf.EWF(mymf, solver=f'EB{ansatz}', bath_options=dict(bathtype='full'),
+                              solver_options=dict(solve_lambda=False, store_as_ccsd=False))
         emb.kernel()
         import ebcc
 
-        cc = ebcc.EBCC(mf, ansatz=ansatz)
+        cc = ebcc.EBCC(mymf, ansatz=ansatz)
         cc.kernel()
 
         self.assertAlmostEqual(emb.e_corr, cc.e_corr)
@@ -54,7 +51,7 @@ class TestEBCC(TestCase):
     def test_rccsdt_water_sto3g(self):
         return self._test('water_sto3g', 'rhf', 'CCSDT')
 
-    @pytest.mark.slow
+    @pytest.mark.veryslow
     def test_uccsdt_water_cation_sto3g(self):
         return self._test('water_cation_sto3g', 'uhf', 'CCSDT')
 
@@ -70,13 +67,13 @@ class TestEBCCActSpace(TestCase):
     def _test(self, system, mf, actansatz, fullansatz, bathtype='dmet', setcas=False):
         # Test that active space calculation with complete active space reproduces equivalent calculation using higher-
         # level approach of active space. This defaults to a DMET bath space.
-        mf = getattr(getattr(testsystems, system), mf)()
+        mymf = getattr(getattr(testsystems, system), mf)()
 
-        embfull = vayesta.ewf.EWF(mf, solver=f'EB{fullansatz}', bath_options=dict(bathtype=bathtype),
+        embfull = vayesta.ewf.EWF(mymf, solver=f'EB{fullansatz}', bath_options=dict(bathtype=bathtype),
                               solver_options=dict(solve_lambda=False))
         embfull.kernel()
 
-        embact = vayesta.ewf.EWF(mf, solver=f'EB{actansatz}', bath_options=dict(bathtype=bathtype),
+        embact = vayesta.ewf.EWF(mymf, solver=f'EB{actansatz}', bath_options=dict(bathtype=bathtype),
                               solver_options=dict(solve_lambda=False))
         if setcas:
             # Set up fragmentation, then set CAS to complete cluster space in previous calculation.
@@ -97,7 +94,7 @@ class TestEBCCActSpace(TestCase):
     def test_uccsdtprime_water_sto3g_dmet(self):
         return self._test('water_sto3g', 'uhf', "CCSDt'", 'CCSDT', bathtype='dmet', setcas=False)
 
-    @pytest.mark.slow
+    @pytest.mark.vslow
     def test_rccsdtprime_h4_sto3g_setcas_full(self):
         return self._test('h4_sto3g', 'rhf', "CCSDt'", 'CCSDT', bathtype='full', setcas=True)
 


### PR DESCRIPTION
This adds CC wavefunction objects which use `ebcc` as a backend, rather than `pyscf`, along with tests for this functionality.  With this we'll have a bit more flexibility in our wavefunction specifications, as it's compatible with arbitrary CC ansatzes. This is a prerequisite to making more use of coupled electron-boson clusters.

I've also included a small tweak to the `pyproject.toml` which allows tests tagged veryslow to be run; previously our configuration was actually blocking running these tests, even when requested.
