### PR TITLE
Change PySCF version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "scipy>=1.1.0,<=1.10.0",
     "h5py>=2.7",
     "cvxpy>=1.1",
-    "pyscf @ git+https://github.com/pyscf/pyscf@master",
+    "pyscf==2.3.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "scipy>=1.1.0,<=1.10.0",
     "h5py>=2.7",
     "cvxpy>=1.1",
-    "pyscf @ git+https://github.com/pyscf/pyscf@e90d8342e29446365f8570682af4a65fe16be27c",
+    "pyscf @ git+https://github.com/pyscf/pyscf@master",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
I'm not seeing [PySCF issue 1846](https://github.com/pyscf/pyscf/issues/1846) on my side, may have been fixed?

edit: Nevermind, ran with an older build by accident. I made a PR to fix here: https://github.com/pyscf/pyscf/pull/1876
In the meantime, should we use v2.3.0 and stick to PyPI releases from now on?