### PR TITLE
Global WF DM1 using BTensor library

### DIFF
--- a/examples/ewf/molecules/btensor-dm.py
+++ b/examples/ewf/molecules/btensor-dm.py
@@ -1,0 +1,96 @@
+from time import perf_counter
+
+import numpy as np
+
+import pyscf
+import pyscf.gto
+import pyscf.scf
+import pyscf.cc
+import vayesta
+import vayesta.ewf
+
+mol = pyscf.gto.Mole()
+
+nwater = 4
+use_sym = True
+
+if nwater == 1:
+    mol.atom = """
+    O  0.0000   0.0000   0.1173
+    H  0.0000   0.7572  -0.4692
+    H  0.0000  -0.7572  -0.4692
+    """
+elif nwater == 2:
+    mol.atom = """
+    O  2.0000   0.0000   0.1173
+    H  2.0000   0.7572  -0.4692
+    H  2.0000  -0.7572  -0.4692
+    O  6.0000   0.0000   0.1173
+    H  6.0000   0.7572  -0.4692
+    H  6.0000  -0.7572  -0.4692
+    """
+elif nwater == 4:
+    mol.atom = """
+    O  0.0000   0.0000   0.1173
+    H  0.0000   0.7572  -0.4692
+    H  0.0000  -0.7572  -0.4692
+    O  2.0000   0.0000   0.1173
+    H  2.0000   0.7572  -0.4692
+    H  2.0000  -0.7572  -0.4692
+    O  6.0000   0.0000   0.1173
+    H  6.0000   0.7572  -0.4692
+    H  6.0000  -0.7572  -0.4692
+    O  8.0000   0.0000   0.1173
+    H  8.0000   0.7572  -0.4692
+    H  8.0000  -0.7572  -0.4692
+    """
+
+#mol.basis = 'cc-pVDZ'
+#mol.basis = 'cc-pVTZ'
+mol.basis = 'cc-pVQZ'
+mol.output = 'pyscf.txt'
+mol.build()
+
+# Hartree-Fock
+mf = pyscf.scf.RHF(mol)
+mf.kernel()
+
+# Embedded CCSD
+eta = 1e-6
+emb = vayesta.ewf.EWF(mf, bath_options=dict(threshold=eta))
+with emb.fragmentation() as f:
+    if nwater > 1 and use_sym:
+        with f.mirror_symmetry(axis='x', center=(4, 0, 0)):
+            for i in range(mol.natm//2):
+                f.add_atomic_fragment(i)
+    else:
+        f.add_all_atomic_fragments()
+emb.kernel()
+
+
+# Density-matrix
+
+#svd_tol = 1e-3
+svd_tol = None
+ovlp_tol = None
+with_t1 = True
+
+times = [perf_counter()]
+dm1 = emb._make_rdm1_ccsd_global_wf(svd_tol=svd_tol, ovlp_tol=ovlp_tol, with_t1=with_t1, use_sym=use_sym)
+times.append(perf_counter())
+
+print(f"Vayesta time 1= {times[1]-times[0]:.3f}")
+
+times = [perf_counter()]
+dm1_bt1 = emb._make_rdm1_ccsd_global_wf_btensor(with_t1=with_t1, svd_tol=svd_tol, ovlp_tol=ovlp_tol, use_sym=use_sym)
+times.append(perf_counter())
+dm1_bt1 = emb._make_rdm1_ccsd_global_wf_btensor(with_t1=with_t1, svd_tol=svd_tol, ovlp_tol=ovlp_tol, use_sym=use_sym)
+times.append(perf_counter())
+dm1_bt1 = emb._make_rdm1_ccsd_global_wf_btensor(with_t1=with_t1, svd_tol=svd_tol, ovlp_tol=ovlp_tol, use_sym=use_sym)
+times.append(perf_counter())
+
+print(f"BTensor time 1= {times[1]-times[0]:.3f}")
+print(f"BTensor time 2= {times[2]-times[1]:.3f}")
+print(f"BTensor time 3= {times[3]-times[2]:.3f}")
+
+print(f"Error in DM= {np.linalg.norm(dm1_bt1 - dm1)}")

--- a/vayesta/ewf/ewf.py
+++ b/vayesta/ewf/ewf.py
@@ -28,6 +28,7 @@ from vayesta.ewf.rdm import make_rdm1_ccsd_global_wf
 from vayesta.ewf.rdm import make_rdm2_ccsd_global_wf
 from vayesta.ewf.rdm import make_rdm1_ccsd_proj_lambda
 from vayesta.ewf.rdm import make_rdm2_ccsd_proj_lambda
+from vayesta.ewf.rdm import make_rdm1_ccsd_global_wf_btensor
 from vayesta.ewf.icmp2 import get_intercluster_mp2_energy_rhf
 
 
@@ -267,6 +268,15 @@ class EWF(Embedding):
     @log_method()
     def _make_rdm1_ccsd_global_wf(self, *args, ao_basis=False, with_mf=True, **kwargs):
         dm1 = self._make_rdm1_ccsd_global_wf_cached(*args, **kwargs)
+        if with_mf:
+            dm1[np.diag_indices(self.nocc)] += 2
+        if ao_basis:
+            dm1 = dot(self.mo_coeff, dm1, self.mo_coeff.T)
+        return dm1
+
+    @log_method()
+    def _make_rdm1_ccsd_global_wf_btensor(self, *args, ao_basis=False, with_mf=True, **kwargs):
+        dm1 = make_rdm1_ccsd_global_wf_btensor(self, *args, **kwargs)
         if with_mf:
             dm1[np.diag_indices(self.nocc)] += 2
         if ao_basis:


### PR DESCRIPTION
This is a draft for a PR to add my [BTensor](https://github.com/maxnus/btensor) library as a dependence to Vayesta,
in order to simplify certain functions, such as the global WF -> DM routines (I developed it for this purpose).

A short introduction to the library can be found [here](https://maxnus.github.io/btensor/index.html) and a more practical example [here](https://github.com/maxnus/btensor/blob/main/examples/09-example-for-pyscf-user.py).

Improved Contractions
-------------------------

The $T_2 \times L_2$ contractions currently look like this:

![t2_before](https://github.com/BoothGroup/Vayesta/assets/12769846/53624c2a-7bf4-4256-a3d2-280babc1bc05)

and simplify to (ignore my slightly confused PyCharm syntax highlighting):

![t2_after_1](https://github.com/BoothGroup/Vayesta/assets/12769846/a7d92147-d301-4b5e-a88a-af49c876a4f2)
with
![t2_after_2](https://github.com/BoothGroup/Vayesta/assets/12769846/4da503a8-d31e-4a18-a36a-77e1ea26dbd5)
and some additional setup such as:
![t2_after_3](https://github.com/BoothGroup/Vayesta/assets/12769846/92e1a0c9-0ca0-4964-869d-a028a125e132)
to initialize the `theta` and `l2` tensor objects.

Overlap matrices between cluster bases are automatically added by the library. 
It also supports contraction over an intermediately constructed and pruned "intersection" basis, via the `intersect_tol` argument to `einsum`. This avoids having the `svd_tol` logic in the 1-DM routine. Note however, that with a finite `svd_tol`, the results will be slightly different to the original implementation for some fairly technical reasons (but as fas as I can tell, not worse when compared to the non-approximated DM, i.e. both are valid approximations).

Dealing with Symmetry
--------------------------

Contributions from symmetry-derived fragments `fx` are currently included like this:

![symmetry_before](https://github.com/BoothGroup/Vayesta/assets/12769846/d55263f6-cf17-4a1f-aa90-efea5fdab84d)

This is difficult to understand, but means the following:

Loop over all fragments `fx2` deriving from `fx` (via the `loop_symmetry_children` generator) and take the tuple of arrays
`(fx,.cluster.c_occ, fx.cluster.c_vir, doox, dvvx)` and perform the respective symmetry operations along axis `[0, 0, 1, 1]`,
respectively. The result of this (named `cx2_occ`, etc), will then be transformed accordingly and added to the final DM.
For nested symmetries, say translations + rotations, the generator will automatically keep the intermediately transformed arrays (for example, an array that has been translated, but not yet rotated) stored, to avoid performing the same operations more than once.

In the btensor version, we deal with the symmetry a bit differently:

![symmetry_after](https://github.com/BoothGroup/Vayesta/assets/12769846/768a95b7-2430-44dd-8949-0fc857cefd5a)

Here, we first transform the desired quantity into the AO basis and then loop over a set of symmetry-transformed `ao_sym` bases and use the `replace_basis` method to replace the basis of the `doox3` and `dvvx3` tensors inplace (active transformation).
We can then add the result to `doo` and `dvv` (which are tensors in the occupied/virtual MO basis), since the library will perform the required back transformation automatically.

I think this way of dealing with symmetry is definitely easier to understand, but I'm not yet fully sure about performance implications. At the moment, `ao` and `ao_sym` are related via full $N_\text{AO}^2$ matrices (except for translations, which are pure permutations), so the transformations will be $N^3$. In principle, all these matrices should be sparse and block diagonal, since only the rotations between the angular momentum orbitals around their center lead to contributions that cannot be described by a permutation; so it should be possible to deal with the transformation more efficiently for large matrices. 
 
For completeness, the `ao_sym` generator looks like this, :
 
![symmetry_loop](https://github.com/BoothGroup/Vayesta/assets/12769846/4feec8d8-0633-4ac7-a7cb-02a738a048e1)

Performance and Testing
---------------------------

So far, performance seems to be looking good, especially without using the SVD approximation.
This is for 4 $\times$ $\text{H}_2\text{O}$ in cc-pVQZ, without `svd_tol` (time in seconds):

![without_svd](https://github.com/BoothGroup/Vayesta/assets/12769846/9a6de3d6-9bcc-42e6-bb10-99c34c998177)
and with `svd_tol = 1e-3`:

![with_svd](https://github.com/BoothGroup/Vayesta/assets/12769846/6ee1b7c0-9c82-4c60-a8db-daf64ca08420)

The script for this can be found [here](examples/ewf/molecules/btensor-dm.py)

However, I think we need to perform a bit more testing around performance, especially for large systems, with and without SVD tolerance, with and without symmetry, and with MPI, and pay attention to both runtime and memory, before we commit to this way of handling basis transformations. Maybe we should also have a more detailed confirmation that this new SVD approximation is not worse than the current one, when comparing to the non-approximated output. We might also have to reassess the domain, where SVD makes sense, given that non-SVD is faster for the example here (we still have the possibility to skip cluster-pairs based on their overlap).