### PR TITLE
[draft] Update ci.yaml to address nightly CI failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          # cache: 'pip'
+          cache: 'pip'
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip
@@ -36,7 +36,7 @@ jobs:
           python -m pip install wheel --user
           python -m pip install setuptools --upgrade --user
           python -m pip install https://github.com/BoothGroup/dyson/archive/master.zip
-          python -m pip install -e .[dmet,ebcc] --user
+          python -m pip install .[dmet,ebcc] --user
       - name: Run unit tests
         run: |
           python -m pip install pytest pytest-cov --user
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-          # cache: 'pip'
+          cache: 'pip'
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
           - {python-version: "3.11", os: ubuntu-latest, documentation: False}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -71,9 +71,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
           cache: 'pip'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           python -m pip install wheel --user
           python -m pip install setuptools --upgrade --user
           python -m pip install https://github.com/BoothGroup/dyson/archive/master.zip
-          python -m pip install .[dmet, ebcc] --user
+          python -m pip install .[dmet,ebcc] --user
       - name: Run unit tests
         run: |
           python -m pip install pytest pytest-cov --user

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           python -m pip install wheel --user
           python -m pip install setuptools --upgrade --user
           python -m pip install https://github.com/BoothGroup/dyson/archive/master.zip
-          python -m pip install .[dmet,ebcc] --user
+          python -m pip install .[dmet, ebcc] --user
       - name: Run unit tests
         run: |
           python -m pip install pytest pytest-cov --user

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
           - {python-version: "3.11", os: ubuntu-latest, documentation: False}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -71,9 +71,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           cache: 'pip'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          # cache: 'pip'
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-          cache: 'pip'
+          # cache: 'pip'
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Changed from pip install -e to pip install . for Vayesta seems to fix this unbeknownst to me why. I am unsure why codecov returns 0.0% now. @obackhouse do you maybe have a clue what might be causing this? 