### PR TITLE
Set fragment converged property from callback results

### DIFF
--- a/vayesta/solver/callback.py
+++ b/vayesta/solver/callback.py
@@ -47,4 +47,5 @@ class CallbackSolver(ClusterSolver):
             
         results['wf'] = wf
         self.wf = wf
+        self.converged = results['converged'] if 'converged' in results else False
         self.callback_results = results


### PR DESCRIPTION
The `converged` property on the fragments results from a callback solver were not properly set. This fixes it and sets the property to the value present in the callback results, if present.