### PR TITLE
Add support for directories in cluster mol output

### DIFF
--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -1,3 +1,4 @@
+import os
 import dataclasses
 from typing import Optional
 
@@ -309,7 +310,11 @@ class RClusterHamiltonian:
         # Copy over all output controls from original mol object.
         clusmol.verbose = self.orig_mf.mol.verbose
         if self.orig_mf.mol.output is not None:
-            clusmol.output = f"f{self._fragment.id}_{self.orig_mf.mol.output}"
+            fid = self._fragment.id
+            output = self.orig_mf.mol.output
+            dirname = os.path.dirname(output)
+            basename = os.path.basename(output)
+            clusmol.output = os.path.join(dirname, f"f{fid}_{basename}")
             self.log.debugv("Setting solver output file to %s", clusmol.output)
         # Set information as required for our cluster.
         clusmol.nelec = self.nelec


### PR DESCRIPTION
The definition of the output on the cluster `mol` object didn't support setting it to a particular path. This meant that the output file from the cluster `mol` object was always stored in the current working directory, rather than where the output file of the main mean-field `mol` object was set to. This pull request fixes it, so that all PySCF output files are now stored in the same user defined directory.