### PR TITLE
Freeze `ebcc` to 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dyson = [
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
 ]
 ebcc = [
-    "ebcc",
+    "ebcc<=1.5.0",
 ]
 pygnme = [
     "pygnme @ git+https://github.com/BoothGroup/pygnme@master" 
@@ -75,7 +75,7 @@ dev = [
     "cvxpy>=1.1",
     "mpi4py>=3.0.0",
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
-    "ebcc",
+    "ebcc<=1.5.0",
     "black>=22.6.0",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
Freezes the `ebcc` version until #182 is addressed
