### PR TITLE
Calculate relevant RDM when using callback solver

### DIFF
--- a/examples/ewf/molecules/64-callback-solver-dms.py
+++ b/examples/ewf/molecules/64-callback-solver-dms.py
@@ -42,6 +42,7 @@ nfrag = 1
 bath_opts = dict(bathtype="dmet")   
 
 # Run vayesta with user defined solver
+# NOTE: if the callback solver only returns RDMs, then energy_functional must be set to 'dmet'
 emb = vayesta.ewf.EWF(mf, solver="CALLBACK",  energy_functional='dmet', bath_options=bath_opts, solver_options=dict(callback=solver))
 # Set up fragments
 with emb.iaopao_fragmentation() as f:

--- a/examples/ewf/molecules/66-callback-solver-dms-uhf.py
+++ b/examples/ewf/molecules/66-callback-solver-dms-uhf.py
@@ -39,6 +39,7 @@ nfrag = 1
 bath_opts = dict(bathtype="dmet")   
 
 # Run vayesta with user defined solver
+# NOTE: if the callback solver only returns RDMs, then energy_functional must be set to 'dmet'
 emb = vayesta.ewf.EWF(mf, solver="CALLBACK",  energy_functional='dmet', bath_options=bath_opts, solver_options=dict(callback=solver))
 # Set up fragments
 with emb.iaopao_fragmentation() as f:

--- a/vayesta/core/scmf/pdmet.py
+++ b/vayesta/core/scmf/pdmet.py
@@ -14,7 +14,10 @@ class PDMET_RHF(SCMF):
         """DM1 in MO basis."""
         dm_type = self.dm_type
         if dm_type.startswith("default"):
-            dm1 = self.emb.make_rdm1()
+            try:
+                dm1 = self.emb.make_rdm1()
+            except NotImplementedError:
+                dm1 = self.emb.make_rdm1_demo()
         elif dm_type.startswith("demo"):
             dm1 = self.emb.make_rdm1_demo()
         else:

--- a/vayesta/ewf/ewf.py
+++ b/vayesta/ewf/ewf.py
@@ -247,8 +247,13 @@ class EWF(Embedding):
             return self._make_rdm1_ccsd_global_wf(*args, **kwargs)
         if self.solver.lower() == "mp2":
             return self._make_rdm1_mp2_global_wf(*args, **kwargs)
+        if self.solver.lower() == "callback":
+            try:
+                return self._make_rdm1_ccsd_global_wf(*args, **kwargs)
+            except AttributeError:
+                return self.make_rdm1_demo(*args, **kwargs)     
         if self.solver.lower() == "fci":
-            return self.make_rdm1_demo(*args, **kwargs)
+            return self.make_rdm1_demo(*args, **kwargs)        
         raise NotImplementedError("make_rdm1 for solver '%s'" % self.solver)
 
     def make_rdm2(self, *args, **kwargs):
@@ -319,7 +324,7 @@ class EWF(Embedding):
             # Builds density matrices from projected amplitudes
             return self.get_dm_corr_energy(**kwargs)
         if functional == 'dmet':
-            # Uses projected density matrices
+            # Uses projected density matrices (democratic partitioning)
             return self.get_dmet_energy(**kwargs) - self.e_mf
         raise ValueError("Unknown energy functional: '%s'" % functional)
 


### PR DESCRIPTION
Attempts to calculate WF RDM when using callback solver. If this fails, falls back to democratically partitioned RDM.
Fixes issue when combining p-DMET with a callback solver.
