### PR TITLE
Fix `ebcc` interface

### DIFF
--- a/vayesta/core/types/ebwf/ebcc.py
+++ b/vayesta/core/types/ebwf/ebcc.py
@@ -103,6 +103,12 @@ class REBCC_WaveFunction(EBWavefunction, RCCSD_WaveFunction):
             self.lambdas = ebcc.util.Namespace()
         self.lambdas.l2 = value.transpose((2, 3, 0, 1))
 
+    def _get_amps(self, amplitudes=False):
+        return self.amplitudes 
+
+    def _get_lams(self, lambdas=False, amplitudes=False):
+        return self.lambdas
+
     def _load_function(self, *args, **kwargs):
         return self._driver._load_function(self, *args, **kwargs)
 


### PR DESCRIPTION
Fixes `ebcc` interface for `ebcc>1.5.0`

There are still some test failures -- most are a missing `_get_amps` method, this is not something that I have touched? and a regularly failing test.