### PR TITLE
Specify DF basis for helium for pyscf compatibility

### DIFF
--- a/vayesta/tests/core/qemb/test_fragment.py
+++ b/vayesta/tests/core/qemb/test_fragment.py
@@ -258,7 +258,7 @@ class CellFragmentTests(TestCase):
             frag = f.add_atomic_fragment([0, 1])
 
         for frag in qemb.fragments:
-            self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.261995344528813, self.PLACES)
+            self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.262004437414159, self.PLACES)
 
     def test_iao_aos(self):
         """Test IAO orbital fragmentation."""
@@ -267,7 +267,7 @@ class CellFragmentTests(TestCase):
         with qemb.iao_fragmentation() as f:
             frag = f.add_orbital_fragment([0, 1])
 
-        self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.261995344528813, self.PLACES)
+        self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.262004437414159, self.PLACES)
 
     def test_sao_atoms(self):
         qemb = Embedding(self.mf)
@@ -275,7 +275,7 @@ class CellFragmentTests(TestCase):
             frags = [f.add_atomic_fragment([i * 2, i * 2 + 1]) for i in range(len(qemb.kpts))]
 
         for frag in frags:
-            self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.261995344528689, self.PLACES)
+            self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.262004437414143, self.PLACES)
 
     def test_sao_aos(self):
         """Test SAO orbital fragmentation."""
@@ -284,7 +284,7 @@ class CellFragmentTests(TestCase):
         with qemb.sao_fragmentation() as f:
             frag = f.add_orbital_fragment([0, 1, 2, 3])
 
-        self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.261995344528689, self.PLACES)
+        self.assertAlmostEqual(frag.get_fragment_mf_energy().real, -4.262004437414142, self.PLACES)
 
     def test_dmet_bath(self):
         """Test the DMET bath."""
@@ -296,9 +296,9 @@ class CellFragmentTests(TestCase):
 
         bath = DMET_Bath(frags[1], frags[1].opts.bath_options["dmet_threshold"])
         c_bath, n_bath, c_occenv, c_virenv = bath.make_dmet_bath(frags[0].c_env)
-        self.assertAlmostEqual(self.trace(c_bath), 3.34569601263718, self.PLACES)
-        self.assertAlmostEqual(self.trace(c_occenv), 8.60026059294578, self.PLACES)
-        self.assertAlmostEqual(self.trace(c_virenv), 38.23956564189844, self.PLACES)
+        self.assertAlmostEqual(self.trace(c_bath), 3.3456960703699785, self.PLACES)
+        self.assertAlmostEqual(self.trace(c_occenv), 8.600270717767593, self.PLACES)
+        self.assertAlmostEqual(self.trace(c_virenv), 38.23955545934385, self.PLACES)
 
         # bath = DMET_Bath(frags[0], frags[0].opts.dmet_threshold)
         # c_bath, c_occenv, c_virenv = bath.make_dmet_bath(frags[0].c_env, nbath=c_bath.shape[-1])  #FIXME bug #5 (these values are old)
@@ -313,8 +313,8 @@ class CellFragmentTests(TestCase):
         bath = DMET_Bath(frags[0], 1e-5)
         c_bath, n_bath, c_occenv, c_virenv = bath.make_dmet_bath(frags[0].c_env, verbose=False)
         self.assertAlmostEqual(self.trace(c_bath), 0.00000000000000, self.PLACES)
-        self.assertAlmostEqual(self.trace(c_occenv), 8.60025893931299, self.PLACES)
-        self.assertAlmostEqual(self.trace(c_virenv), 38.23956182500297, self.PLACES)
+        self.assertAlmostEqual(self.trace(c_occenv), 8.600269067531315, self.PLACES)
+        self.assertAlmostEqual(self.trace(c_virenv), 38.239551696784666, self.PLACES)
 
 
 if __name__ == "__main__":

--- a/vayesta/tests/core/test_foldscf.py
+++ b/vayesta/tests/core/test_foldscf.py
@@ -50,11 +50,7 @@ class FoldSCF_UHF_Tests(FoldSCF_RHF_Tests):
     def setUpClass(cls):
         cls.kmf = testsystems.he2_631g_k222.uhf()
         cls.mf = foldscf.fold_scf(cls.kmf)
-        cls.scell = testsystems.he2_631g_s222.mol
-        cls.smf = scf.UHF(cls.scell)
-        cls.smf.conv_tol = 1e-12
-        cls.smf = cls.smf.density_fit()
-        cls.smf.kernel()
+        cls.smf = testsystems.he2_631g_s222.uhf()
 
 
 if __name__ == "__main__":

--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -455,7 +455,7 @@ he_k3 = TestSolid(a, atom="He 0 0 0", dimension=1, basis="def2-svp", auxbasis="d
 he_s3 = TestSolid(a, atom="He 0 0 0", dimension=1, basis="def2-svp", auxbasis="def2-svp-ri", supercell=(3, 1, 1))
 
 a = np.eye(3) * 5
-opts = dict(basis="6-31g", mesh=[11, 11, 11])
+opts = dict(basis="631g", auxbasis='def2-svp-ri', mesh=[11, 11, 11])
 he2_631g_k222 = TestSolid(a=a, atom="He 3 2 3; He 1 1 1", kmesh=(2, 2, 2), **opts)
 he2_631g_s222 = TestSolid(a=a, atom="He 3 2 3; He 1 1 1", supercell=(2, 2, 2), **opts)
 


### PR DESCRIPTION
Pyscf has updated the default DF basis selection. Need to specify a DF basis for 631g Helium.
