### PR TITLE
Update for compatibility with numpy 2.3.0

### DIFF
--- a/vayesta/core/screening/screening_moment.py
+++ b/vayesta/core/screening/screening_moment.py
@@ -98,10 +98,11 @@ def build_screened_eris(emb, fragments=None, cderi_ov=None, store_m0=True, npoin
         # indices.
         no = f.cluster.nocc_active
         nv = f.cluster.nvir_active
-        if isinstance(no, int):
+        if isinstance(no, (int, np.int64)):
             no = (no, no)
             nv = (nv, nv)
 
+        print("no: %s = %s"%(type(no), str(no)))
         kcaa = kc[:ova, :ova].reshape((no[0], nv[0], no[0], nv[0]))
         kcab = kc[:ova, ova:].reshape((no[0], nv[0], no[1], nv[1]))
         kcbb = kc[ova:, ova:].reshape((no[1], nv[1], no[1], nv[1]))

--- a/vayesta/edmet/fragment.py
+++ b/vayesta/edmet/fragment.py
@@ -382,7 +382,7 @@ class EDMETFragment(DMETFragment):
 
     def get_xc_couplings(self, xc_kernel, rot):
         ov_mf = self.ov_mf
-        if isinstance(ov_mf, int):
+        if isinstance(ov_mf, (int, np.int64)):
             ov_mf = (ov_mf, ov_mf)
 
         rota, rotb = rot[:, : ov_mf[0]], rot[:, ov_mf[0] : sum(ov_mf)]
@@ -1229,7 +1229,7 @@ class EDMETFragment(DMETFragment):
     @property
     def ov_active_ab(self):
         ov = self.ov_active
-        if isinstance(ov, int):
+        if isinstance(ov, (int, np.int64)):
             return (ov, ov)
         else:
             return ov
@@ -1237,7 +1237,7 @@ class EDMETFragment(DMETFragment):
     @property
     def nocc_ab(self):
         no = self.cluster.nocc_active
-        if isinstance(no, int):
+        if isinstance(no, (int, np.int64)):
             return (no, no)
         else:
             return no

--- a/vayesta/solver/hamiltonian.py
+++ b/vayesta/solver/hamiltonian.py
@@ -858,7 +858,7 @@ class EB_RClusterHamiltonian(RClusterHamiltonian):
 
     def set_polaritonic_shift(self, freqs, couplings):
         no = self.cluster.nocc_active
-        if isinstance(no, int):
+        if isinstance(no, (int, np.int64)):
             noa = nob = no
         else:
             noa, nob = no


### PR DESCRIPTION
Convert checks for type `int` to check for types `int`, `np.int64` to fix changes in numpy 2.3.0