### PR TITLE
Fix for 1D systems

### DIFF
--- a/vayesta/tests/testsystems.py
+++ b/vayesta/tests/testsystems.py
@@ -451,8 +451,8 @@ he_s32 = TestSolid(
 
 a = np.eye(3) * 3.0
 a[1, 1] = a[2, 2] = 30.0
-he_k3 = TestSolid(a, atom="He 0 0 0", dimension=1, basis="def2-svp", auxbasis="def2-svp-ri", kmesh=(3, 1, 1))
-he_s3 = TestSolid(a, atom="He 0 0 0", dimension=1, basis="def2-svp", auxbasis="def2-svp-ri", supercell=(3, 1, 1))
+he_k3 = TestSolid(a, atom="He 0 0 0", dimension=1, low_dim_ft_type='inf_vacuum', basis="def2-svp", auxbasis="def2-svp-ri", kmesh=(3, 1, 1))
+he_s3 = TestSolid(a, atom="He 0 0 0", dimension=1, low_dim_ft_type='inf_vacuum', basis="def2-svp", auxbasis="def2-svp-ri", supercell=(3, 1, 1))
 
 a = np.eye(3) * 5
 opts = dict(basis="631g", auxbasis='def2-svp-ri', mesh=[11, 11, 11])


### PR DESCRIPTION
Pyscf now requires `low_dim_ft_type='inf_vacuum'` set for 1D systems