### PR TITLE
fix: correct [tools.setuptools] typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ dynamic = ["version"]
 requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"
 
-[tools.setuptools]
+[tool.setuptools]
 license-files = ["LICENSE"]
 
-[tools.setuptools.dynamic]
+[tool.setuptools.dynamic]
 version = {attr = "vayesta.__version__"}
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Fixes a typo in `pyproject.toml`: the setuptools configuration table was written as `[tools.setuptools]` and `[tools.setuptools.dynamic]` (plural), but PEP 518 requires the singular `[tool.setuptools]`.

## Why

Setuptools silently ignores the misspelled table name, so:

- `pip install .` / `pip install vayesta @ git+...` wheel builds fail for all users
- the `license-files` and dynamic `version` attributes are not picked up
- users are forced into a clone + `.pth` workaround

## What changes

Two lines: `[tools.setuptools]` → `[tool.setuptools]` and `[tools.setuptools.dynamic]` → `[tool.setuptools.dynamic]`. No functional change beyond making the declared build-backend configuration actually take effect.

## Verification

`pip install .` now proceeds past the setuptools configuration stage instead of failing to find the config table.
